### PR TITLE
Bringing back old features

### DIFF
--- a/SRPG_AIControl.js
+++ b/SRPG_AIControl.js
@@ -6,7 +6,7 @@
 //=============================================================================
 
 /*:
- * @plugindesc SRPG advanced AI (v0.9), edited by OhisamaCraft
+ * @plugindesc SRPG advanced AI (v0.9), edited by Shoukang, OhisamaCraft
  * @author Dr. Q
  * 
  * @param Target Formula
@@ -446,6 +446,8 @@
 			} else {
 				$gameTemp.clearMoveTable();
 				user.onAllActionsEnd();
+				$gameTemp.clearAreaTargets(); //shoukang clear areas
+				$gameTemp.clearArea(); //shoukang clear areas
 				return false;
 			}
 		}
@@ -614,7 +616,7 @@
 			if ($gameTemp.areaTargets().length > 0) {
 				bestTarget = $gameTemp.areaTargets().shift().event;
 			}
-			$gameTemp.clearArea();
+			// shoukang delete $gameTemp.clearArea();
 		}
 		// set the optimal target and position
 		$gameTemp.setTargetEvent(bestTarget);

--- a/SRPG_AoEAnimation.js
+++ b/SRPG_AoEAnimation.js
@@ -1,0 +1,974 @@
+//=============================================================================
+//SRPG_AoEAnimation.js
+// v 1.06 Fix a bug of showing the wrong battler in battle result window.
+// Use my bug fix patch! Especially the SRPG_DynamicAction, the map AoE battle will work amazingly good!
+// Download here https://github.com/ShoukangHong/Shoukang_SRPG_plugin/tree/main/BugFixPatch
+//=============================================================================
+/*:
+ * @plugindesc Allows AoE skills to show once when targetting multiple targets. Requires SRPG_AoE. This is a modified version by Shoukang
+ * @author Boomy, Shoukang
+ * 
+ * @param standard X
+ * @desc The center X position in battle scene, default Graphics.width / 2
+ * @default Graphics.width / 2
+ * 
+ * @param standard Y
+ * @desc The center Y position in battle scene, default Graphics.height / 2 + 48
+ * @default Graphics.height / 2 + 48
+ * 
+ * @param x range
+ * @desc x direction battler placement range in battle scene, default Graphics.width - 360
+ * @default Graphics.width - 360
+ *
+ * @param y range
+ * @desc y direction battler placement range in battle scene, default Graphics.height / 3.5
+ * @default Graphics.height / 3.5
+ * 
+ * @param tilt
+ * @desc parameter that tilt x direction placement to simulate a 3D view, default 0.2
+ * @default 0.2
+ *
+ * @param allow surrounding
+ * @desc if disabled skill user will never be surrounded by targets. See help for detail
+ * @type boolean
+ * @default false
+ *
+ * @param counterattack Mode
+ * @desc what targets in the AoE can do counterattack
+ * @type select
+ * @option All targets
+ * @value all
+ * @option target in AoE center
+ * @value center
+ * @option first viable target
+ * @value first
+ * @option No AoE counter
+ * @value false
+ * @default all
+ *
+ * @help
+ * ===================================================================================================
+ * Compatibility:
+ * Need SRPG_AoE, and place this plugin below it.
+ * Strongly recommend to use my bug fix patch! Especially the SRPG_DynamicAction, the map AoE battle will work amazingly good!
+ * Download here https://github.com/ShoukangHong/Shoukang_SRPG_plugin/tree/main/BugFixPatch
+ * ===================================================================================================
+ * When an AoE spell is cast and more than 1 target is selected ($gameTemp.areaTargets), each target is added to a queue and then the game will execute each battle individually 1 on 1
+ * This script will collect all targets and add them into one battle for a 1 vs many scenario
+ * Works best with animations set to SCREEN though animations that target individuals still work (they just happened sequentially on the same battle field)
+ *
+ * AoE rules in this plugin:
+ * 1. If an enemy cast AoE to actors, the battle exp will be shared by all actors in battle equally.
+ * 2. If you use AGI attack, AoE skill will hit every target first, then targets will do counter attacks.
+ *
+ * Important Tips:
+ * With this plugin, it's necessary to set skill target to all enemies/friends to make AoEs work properly.
+ * If you allow surrounding and you use dynamic motion, actor sprite priority may become weird while casting skills, to avoid this, set the plugin parameter
+ * 'usePriority' in dynamic motion to false.
+ * Once you find anything weird, try to turn of this plugin and see if it happens again. This will help us identify which plugin causes the error.
+ * ==================================================================================================
+ * Positions battlers in Battle scene:
+ * All battlers will be placed based on their relative positions. For example in this map position:
+ * [ . T .]    Battle scene will look like: [ . T .]                     [ . T .]
+ * [ T C T]    ========================>    [ T . U] when user is actor, [ U . T] when user is enemy.
+ * [ . U .]                                 [ . T .]                     [ . T .]
+ *
+ * U: skill user, T: target, C; AoE center
+ *
+ * The battle scene will look like:
+ * [ C T .]    Battle scene will look like: [ T . .]                     [ . . T]
+ * [ T U .]    ========================>    [ . . U] when user is actor, [ U . .] when user is enemy.
+ * [ . . .]                                 [ T . .]                     [ . . T]
+ *
+ * The placement will automatically adjust battlers' distance to make them reasonable.(within the defined x and y range)
+ * ===================================================================================================
+ * Credits to: Dopan, Dr. Q, Traverse, SoulPour777
+ * ===================================================================================================
+ * v 1.06 Fix a bug of showing the wrong battler in battle result window.
+ * v 1.05 add map battle log window. Need to update the SRPG_DynamicAction to work. Fix a bug where agi attack continue when enemy is already dead.
+ * v 1.04 fixed some bugs and improve logic. Now the map battle should work completely the same as scene battle.  Also updates SRPG_DynamicAction
+ * v 1.03 fixed some bugs
+ * v 1.02 Change battle result window to fit for more reward items.
+ *        Fix a bug that counter attack don't stop when active battler is dead.
+ *        Map view AoE now behaves the same as Scene battle, which means: 1. AoE Animation cast simultaniusly no matter it's
+ * dynamic animation or not. 2. All targets get hit at the beginning. 3. Damage for AoE pop up simultaniusly.
+ * v 1.01 add counter attack mode! Fix a bug caused by max party member, fix the bug of sprite priority in battle.
+ */
+(function () {
+    'use strict'
+    //=================================================================================================
+    //Plugin Parameters
+    //=================================================================================================
+    var parameters = PluginManager.parameters('SRPG_AoEAnimation');
+    var _standardY = parameters['standard Y'] || 'Graphics.height / 2 + 48';
+    var _standardX = parameters['standard X'] || 'Graphics.width / 2';
+    var _xRange = parameters['x range'] || 'Graphics.width - 360';
+    var _yRange = parameters['y range'] || 'Graphics.height / 3.5';
+    var _tilt = Number(parameters['tilt']);
+    var _surround = !!eval(parameters['allow surrounding']);
+    var _counterMode = parameters['counterattack Mode'];
+
+    var coreParameters = PluginManager.parameters('SRPG_core');
+    var _srpgTroopID = Number(coreParameters['srpgTroopID'] || 1);
+    var _srpgUseAgiAttackPlus = coreParameters['useAgiAttackPlus'] || 'true';
+    var _srpgAgilityAffectsRatio = Number(coreParameters['srpgAgilityAffectsRatio'] || 2);
+    var _existActorVarID = Number(coreParameters['existActorVarID'] || 1);
+    var _existEnemyVarID = Number(coreParameters['existEnemyVarID'] || 2);
+    var _srpgBattleExpRate = Number(coreParameters['srpgBattleExpRate'] || 0.4);
+    var _srpgBattleExpRateForActors = Number(coreParameters['srpgBattleExpRateForActors'] || 0.1);
+    var _rewardSe = coreParameters['rewardSound'] || 'Item3';
+    var _expSe = coreParameters['expSound'] || 'Up4';
+    var _srpgDamageDirectionChange = coreParameters['srpgDamageDirectionChange'] || 'true';
+//============================================================================================
+//Battler position in AoE(when there are areaTargets) scene battle 
+//============================================================================================
+    // remove actor sprite limit
+    var _Spriteset_Battle_createActors = Spriteset_Battle.prototype.createActors
+    Spriteset_Battle.prototype.createActors = function() {
+        if ($gameSystem.isSRPGMode() && $gameTemp.areaTargets().length > 0){
+            this._actorSprites = [];
+            for (var i = 0; i < $gameParty.SrpgBattleActors().length; i++) {
+                this._actorSprites[i] = new Sprite_Actor();
+                this._battleField.addChild(this._actorSprites[i]);
+            }          
+        } else{
+            _Spriteset_Battle_createActors.call(this);
+        }
+    };
+
+    //sort to get priority right
+    var _Spriteset_Battle_createLowerLayer = Spriteset_Battle.prototype.createLowerLayer;
+    Spriteset_Battle.prototype.createLowerLayer = function() {
+        _Spriteset_Battle_createLowerLayer.call(this);
+        if ($gameSystem.isSRPGMode() && $gameTemp.areaTargets().length > 0){
+            this._battleField.removeChild(this._back1Sprite);
+            this._battleField.removeChild(this._back2Sprite);
+            this._battleField.children.sort(this.compareEnemySprite.bind(this));
+            this._battleField.addChildAt(this._back2Sprite, 0);
+            this._battleField.addChildAt(this._back1Sprite, 0);
+        }
+    };
+
+    var _SRPG_Sprite_Actor_setActorHome = Sprite_Actor.prototype.setActorHome;
+    Sprite_Actor.prototype.setActorHome = function (index) {
+        if ($gameSystem.isSRPGMode() == true && !$gameSystem.useMapBattle() && $gameTemp.areaTargets().length > 0) {
+            var param = $gameTemp._aoePositionParameters;
+            var battler = this._battler;
+            this.setHome(eval(_standardX) + (battler.aoeSceneX() - param.midX) * param.amplifyX,
+                         eval(_standardY) + (battler.aoeSceneY() - param.midY) * param.amplifyY);
+            this.moveToStartPosition();
+        } else {
+            _SRPG_Sprite_Actor_setActorHome.call(this, index);
+        }
+    };
+
+    //Set enemy positions
+    var _SRPG_Game_Troop_setup = Game_Troop.prototype.setup;
+    Game_Troop.prototype.setup = function(troopId) {
+        if ($gameSystem.isSRPGMode() == true && !$gameSystem.useMapBattle() && $gameTemp.areaTargets().length > 0) {
+            this.clear();
+            this._troopId = troopId;
+            this._enemies = [];
+            var param = $gameTemp._aoePositionParameters;
+            for (var i = 0; i < this.SrpgBattleEnemys().length; i++) {
+                var battler = this.SrpgBattleEnemys()[i];
+                battler.setScreenXy(eval(_standardX) + (battler.aoeSceneX() - param.midX) * param.amplifyX,
+                                    eval(_standardY) + (battler.aoeSceneY() - param.midY) * param.amplifyY);
+                this._enemies.push(battler);
+            }
+            this.makeUniqueNames();
+        } else {
+            _SRPG_Game_Troop_setup.call(this, troopId);
+        }
+    };
+
+// shoukang: complicated vector calculation to determine the battler placement parameters and relative position.
+    Scene_Map.prototype.setBattlerPosition = function(){
+        var activeEvent = $gameTemp.activeEvent();
+        var allEvents = [activeEvent, $gameTemp.targetEvent()].concat($gameTemp.getAreaEvents());
+        var vector =  this.createSrpgAoEVector();
+        var vectorX = vector[0];
+        var vectorY = vector[1];
+        var vectorLen = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+        var minX = 0;
+        var maxX = 0.5;
+        var minY = -1.25;
+        var maxY = 1.25;
+        var targetMinX = 0.5;
+
+        for (var i = 0; i < allEvents.length; i++){
+            var battler = $gameSystem.EventToUnit(allEvents[i].eventId())[1];
+            var posX = allEvents[i].posX() - activeEvent.posX();
+            var posY = allEvents[i].posY() - activeEvent.posY();
+            var projectionY = (vectorY * posX - vectorX * posY) / vectorLen;
+            var projectionX = _tilt * projectionY + (vectorX * posX + vectorY * posY) / vectorLen; //0.2 * sin helps to make a better veiw.
+            battler.setAoEScenePosition(projectionX, projectionY);
+            if (i > 0) targetMinX = Math.min(projectionX, targetMinX);
+            minX = Math.min(projectionX, minX);
+            minY = Math.min(projectionY, minY);
+            maxX = Math.max(projectionX, maxX);
+            maxY = Math.max(projectionY, maxY);
+        }
+
+        if (!_surround && targetMinX < 0.5){
+            minX -= Math.max((maxX - targetMinX) / 2, 0.5);
+            $gameSystem.EventToUnit(activeEvent.eventId())[1].setAoEScenePosition(minX, 0);
+        }
+        var direction = $gameSystem.EventToUnit(activeEvent.eventId())[0] === 'actor' ? -1 : 1;
+        var amplifyX = direction * eval(_xRange) / Math.max((maxX - minX), 2);
+        var amplifyY = eval(_yRange) / (maxY - minY);
+        $gameTemp.setAoEPositionParameters((minX + maxX) / 2, (minY + maxY) / 2, amplifyX, amplifyY);
+    }
+
+    Scene_Map.prototype.createSrpgAoEVector = function(){
+        var activeEvent = $gameTemp.activeEvent();
+        var vectorX = $gameTemp.areaX() - activeEvent.posX();
+        var vectorY = $gameTemp.areaY() - activeEvent.posY();
+
+        // if aoe center overlap with active event, use active event direction as vector.
+        if (Math.abs(vectorX) + Math.abs(vectorY) === 0){
+            var dir = activeEvent.direction();
+            vectorX = $gameMap.roundXWithDirection(0, dir);
+            vectorY = $gameMap.roundYWithDirection(0, dir);
+        }
+        return [vectorX, vectorY]
+    }
+
+    Game_Battler.prototype.setAoEScenePosition = function(x, y){
+        this._aoeSceneX = x;
+        this._aoeSceneY = y;
+    }
+
+    Game_Battler.prototype.aoeSceneX = function(){
+        return this._aoeSceneX;
+    }
+
+    Game_Battler.prototype.aoeSceneY = function(){
+        return this._aoeSceneY;
+    }
+
+    Game_Temp.prototype.setAoEPositionParameters = function(midX, midY, amplifyX, amplifyY){
+        this._aoePositionParameters = {
+            midX : midX,
+            midY : midY,
+            amplifyX : amplifyX,
+            amplifyY : amplifyY,
+        }
+    }
+
+//============================================================================================
+//AoE animation Main logic
+//============================================================================================
+
+// shoukang rewrite to give a clearer logic
+    Scene_Map.prototype.srpgBattleStart = function(userArray, targetArray){
+        var action = userArray[1].action(0);
+        if (action && action.item()) {
+            var mapBattleTag = action.item().meta.mapBattle;
+            if (mapBattleTag == 'true') $gameSystem.forceSRPGBattleMode('map');
+            else if (mapBattleTag == 'false') $gameSystem.forceSRPGBattleMode('normal');
+        }
+        if (!$gameSystem.useMapBattle()) {
+            this.processSceneBattle(userArray, targetArray);
+        } else {
+            this.processMapBattle(userArray, targetArray)
+        }
+    };
+
+//Scene Battle that take area targets into consideration
+    Scene_Map.prototype.processSceneBattle = function(userArray, targetArray){  
+        var userType = userArray[0];
+        var user = userArray[1];
+        var targetType = targetArray[0]
+        var targetEvents = [$gameTemp.targetEvent()].concat($gameTemp.getAreaEvents());
+        $gameParty.clearSrpgBattleActors();
+        $gameTroop.clearSrpgBattleEnemys();
+        $gameTroop._enemies = [];
+        this.pushSrpgBattler(userType, user);
+        if (userType === 'enemy') {
+            user.action(0).setSrpgEnemySubject($gameTroop.members().length - 1);
+        }
+
+        if($gameTemp.areaTargets().length > 0) {
+            this.setBattlerPosition();
+        }
+
+        for (var i = 0; i < targetEvents.length; i++) {
+            var target = $gameSystem.EventToUnit(targetEvents[i].eventId())[1];
+            this.setTargetDirection(targetEvents[i]);
+            if (user === target){
+                user.action(0).setTarget(0);
+            } else if (userType === targetType) {
+                this.pushSrpgBattler(targetType, target);
+                user.action(0).setTarget(1);
+                target.removeCurrentAction();
+            } else {
+                this.pushSrpgBattler(targetType, target);
+                target.removeCurrentAction();
+                if (i === 0) user.action(0).setTarget(0);
+            }
+            if (!this.counterModeValid(targetEvents[i])) continue;
+            if (userType !== targetType && target.canMove() && !user.currentAction().item().meta.srpgUncounterable) {
+                target.srpgMakeNewActions();
+                if (targetType === 'enemy') {
+                    target.action(0).setSrpgEnemySubject($gameTroop.members().length - 1);
+                }
+                target.action(0).setAttack();
+                var item = target.action(0).item();
+                var distance = $gameSystem.unitDistance($gameTemp.activeEvent(), targetEvents[i]);
+                //console.log(distance, target)
+                target.setAoEDistance(distance);
+                target.action(0).setTarget(0);
+                target.setActionTiming(1);
+                if (_counterMode === 'first' && target.canUse(item)) this._counterCount -= 1;
+            }
+        }
+
+        user.setActionTiming(0);
+        BattleManager.setup($dataTroops[_srpgTroopID] ? _srpgTroopID : 1, false, true);
+
+        this.preBattleSetDirection();
+        //行動回数追加スキルなら行動回数を追加する
+        var addActionNum = Number(user.action(0).item().meta.addActionTimes);
+        if (addActionNum && addActionNum > 0) {
+            user.SRPGActionTimesAdd(addActionNum);
+        }
+        this._callSrpgBattle = true;
+        this.eventBeforeBattle();
+    };
+
+//shoukang: slightly edited from _srpgBattleStart_MB for agi attack plus future improvement.
+    Scene_Map.prototype.processMapBattle = function(userArray, targetArray){
+        var user = userArray[1];
+        var targetEvents = [$gameTemp.targetEvent()].concat($gameTemp.getAreaEvents());
+        var action = user.action(0);
+        // prepare action timing
+        user.setActionTiming(0);
+
+        // pre-skill setup
+        $gameSystem.clearSrpgStatusWindowNeedRefresh();
+        $gameSystem.clearSrpgBattleWindowNeedRefresh();
+        this.preBattleSetDirection();
+
+        // set up the troop and the battle party
+        $gameParty.clearSrpgBattleActors();
+        $gameTroop.clearSrpgBattleEnemys();
+        $gameTroop.clear();
+        BattleManager.setup(_srpgTroopID, false, true);
+        this.pushSrpgBattler(userArray[0], userArray[1]);
+        action.setSubject(user);
+        var hiddenAction = action.createAoERepeatedAction();
+        var addActionTimes = Number(action.item().meta.addActionTimes || 0);
+        if (addActionTimes > 0) user.SRPGActionTimesAdd(addActionTimes);
+        for (var i = 0; i < targetEvents.length; i++) {
+            var target = $gameSystem.EventToUnit(targetEvents[i].eventId())[1];
+            var targetType = $gameSystem.EventToUnit(targetEvents[i].eventId())[0];
+            if (target !== user) {
+                this.pushSrpgBattler(targetType, target);
+            }
+            var act = (i < 1 ? action : hiddenAction);
+            this.srpgAddMapSkill(act, user, target);
+            this.setTargetDirection(targetEvents[i])
+        }
+
+        if (userArray[0] !== targetArray[0]){        
+            this._agiList = []; //make a list to store agi attacks
+            this.srpgAgiAttackPlus(user, targetArray[1], targetEvents); //add agi attack for user
+            this.addTargetCounterAttack(action, user, targetEvents); // add counterattack and agi attack for targets
+            this.pushAgiSkilltoMapSkill(); // agi skill should happen after one round of counter attack.
+        }
+        this.eventBeforeBattle();
+    }
+
+    Scene_Map.prototype.addTargetCounterAttack = function(action, user, targetEvents){
+        for (var i = 0; i < targetEvents.length; i++) {
+            var targetArray = $gameSystem.EventToUnit(targetEvents[i].eventId());
+            var target = targetArray[1];
+            target.setActionTiming(1);
+            if (!this.counterModeValid(targetEvents[i])) continue;
+            if (target.canMove() && !action.item().meta.srpgUncounterable) {
+                target.srpgMakeNewActions();
+                var reaction = target.action(0);
+                reaction.setSubject(target);
+                reaction.setAttack();
+                var distance = $gameSystem.unitDistance($gameTemp.activeEvent(), target.event());
+                target.setAoEDistance(distance);
+                if (!target.canUse(reaction.item())) continue;
+                if (_counterMode === 'first') this._counterCount -= 1;
+                var actFirst = (reaction.speed() > action.speed());
+                if (_srpgUseAgiAttackPlus == 'true') actFirst = false;
+                this.srpgAddMapSkill(reaction, target, user, actFirst);//action, user, target, addToFront
+                this.srpgAgiAttackPlus(target, user, targetEvents);
+            }
+        }
+    }
+
+    Scene_Map.prototype.srpgAgiAttackPlus = function(agiUser, target, targetEvents){
+        if (_srpgUseAgiAttackPlus != 'true') return;
+        if (agiUser.agi <= target.agi) return;
+        if (!agiUser.currentAction() || !agiUser.currentAction().item()) {
+            return;
+        }
+        if (agiUser.currentAction().canAgiAttack()) {
+            var dif = agiUser.agi - target.agi;
+            var difMax = target.agi * _srpgAgilityAffectsRatio - target.agi;
+            if (difMax == 0) {
+                var agilityRate = 100;
+            } else {
+                var agilityRate = dif / difMax * 100;
+            }
+            if (agilityRate > Math.randomInt(100)) {
+                var agiAction = agiUser.action(0);
+                if (agiUser == $gameSystem.EventToUnit($gameTemp.activeEvent().eventId())[1]){
+                    this.addAoESkillToAgiList(agiAction, agiUser, targetEvents);
+                } else {
+                    this.addSkillToAgiList(agiAction, agiUser, target);
+                }
+            }
+        }
+    }
+
+    Scene_Map.prototype.addAoESkillToAgiList = function(action, user, targetEvents, agiList){
+        var hiddenAction = action.createAoERepeatedAction();
+        //console.log(hiddenAction)
+        for (var i = 0; i < targetEvents.length; i++) {
+            var targetArray = $gameSystem.EventToUnit(targetEvents[i].eventId());
+            var act = (i < 1 ? action : hiddenAction);
+            //console.log(userArray[0], userArray[1], targetA[0], targetA[1])
+            this.addSkillToAgiList(act, user, targetArray[1]);
+        }
+    };
+
+    Scene_Map.prototype.addSkillToAgiList = function(action, user, target){
+        this._agiList.push([action, user, target]);
+    };
+
+    Scene_Map.prototype.pushAgiSkilltoMapSkill = function(){
+        for (var i = 0; i < this._agiList.length; i++){
+            var agiInfo = this._agiList[i]
+            this.srpgAddMapSkill(agiInfo[0], agiInfo[1], agiInfo[2]);
+        }
+        this._agiList = [];
+    };
+
+    //helper function
+    Scene_Map.prototype.pushSrpgBattler = function(type, battler){
+        if (type === 'actor' || battler.isActor()) $gameParty.pushSrpgBattleActors(battler);
+        else if (type === 'enemy' || battler.isEnemy()) {
+            $gameTroop.pushSrpgBattleEnemys(battler);
+            $gameTroop.pushMembers(battler);
+        }
+    }
+
+    Scene_Map.prototype.setTargetDirection = function(targetEvent) {
+        if (_srpgDamageDirectionChange != 'true') return;
+        if ($gameTemp.activeEvent() == targetEvent) return;  // 自分自身の時は向きを修正しない
+        var differenceX = $gameTemp.activeEvent().posX() - targetEvent.posX();
+        var differenceY = $gameTemp.activeEvent().posY() - targetEvent.posY();
+        if ($gameMap.isLoopHorizontal() == true) {
+            var event1X = $gameTemp.activeEvent().posX() > targetEvent.posX() ? targetEvent.posX() - $gameMap.width() : $gameTemp.activeEvent().posX() + $gameMap.width();
+            var disX = event1X - targetEvent.posX();
+            differenceX = Math.abs(differenceX) < Math.abs(disX) ? differenceX : disX;
+        }
+        if ($gameMap.isLoopVertical() == true) {
+            var event1Y = $gameTemp.activeEvent().posY() > targetEvent.posY() ? $gameTemp.activeEvent().posY() - $gameMap.height() : $gameTemp.activeEvent().posY() + $gameMap.height();
+            var disY = event1Y - targetEvent.posY();
+            differenceY = Math.abs(differenceY) < Math.abs(disY) ? differenceY : disY;
+        }
+        if (Math.abs(differenceX) > Math.abs(differenceY)) {
+            if (differenceX > 0) targetEvent.setDirection(6);
+            else targetEvent.setDirection(4);
+        } else {
+            if (differenceY >= 0) targetEvent.setDirection(2);
+            else targetEvent.setDirection(8);
+        }
+    };
+
+    // counter mode for AoE
+    Scene_Map.prototype.counterModeValid = function(target){
+        if (!$gameTemp._activeAoE) return true;
+        if (_counterMode === 'center' && target.distTo($gameTemp.areaX(), $gameTemp.areaY()) !== 0) return false;
+        if (_counterMode === 'false') return false;
+        if (_counterMode === 'first' && this._counterCount <= 0) return false;
+        return true;
+    }
+
+    var _Scene_Map_srpgInvokeAutoUnitAction = Scene_Map.prototype.srpgInvokeAutoUnitAction;
+    Scene_Map.prototype.srpgInvokeAutoUnitAction = function() {
+        this._counterCount = 1;
+        _Scene_Map_srpgInvokeAutoUnitAction.call(this);
+    }
+
+    var _Scene_Map_commandBattleStart = Scene_Map.prototype.commandBattleStart
+    Scene_Map.prototype.commandBattleStart = function() {
+        this._counterCount = 1;
+        _Scene_Map_commandBattleStart.call(this);
+    }
+
+    var _Scene_Map_srpgBattlerDeadAfterBattle = Scene_Map.prototype.srpgBattlerDeadAfterBattle;
+    Scene_Map.prototype.srpgBattlerDeadAfterBattle = function() {
+        var activeEvent = $gameTemp.activeEvent();
+        var targetEvent = $gameTemp.targetEvent();
+        var allEvents = [activeEvent, targetEvent].concat($gameTemp.getAreaEvents());
+        $gameTemp.clearAreaTargets();
+
+        for (var i = 0; i < allEvents.length; i++){
+            var event = allEvents[i];
+            var battler = $gameSystem.EventToUnit(event.eventId())[1];
+            battler.clearAoEDistance();
+            if ( i > 0 && event === activeEvent) continue; //active event occurs again, ignore
+            battler.setActionTiming(-1);
+            battler.removeCurrentAction();
+            if (battler && battler.isDead() && !event.isErased()) {
+                event.erase();
+                var valueId = battler.isActor() ? _existActorVarID : _existEnemyVarID;
+                var oldValue = $gameVariables.value(valueId);
+                $gameVariables.setValue(valueId, oldValue - 1);
+            }
+        }
+    };
+
+    //rewrite to give a clearer logic
+    Scene_Battle.prototype.createSprgBattleStatusWindow = function() {
+        this._srpgBattleStatusWindowLeft = new Window_SrpgBattleStatus(0);
+        this._srpgBattleStatusWindowRight = new Window_SrpgBattleStatus(1);
+        this._srpgBattleStatusWindowLeft.openness = 0;
+        this._srpgBattleStatusWindowRight.openness = 0;
+        if (!$gameSystem.isSRPGMode()) return;
+        var userArray = $gameSystem.EventToUnit($gameTemp.activeEvent().eventId());
+        var targetArray = $gameSystem.EventToUnit($gameTemp.targetEvent().eventId());
+        var areaEvents = $gameTemp.getAreaEvents();
+        if (userArray[0] === 'actor') {
+            this._srpgBattleStatusWindowRight.setBattler(userArray[1]);
+            var targetWindow = this._srpgBattleStatusWindowLeft
+        } else {
+            this._srpgBattleStatusWindowLeft.setBattler(userArray[1]);
+            var targetWindow = this._srpgBattleStatusWindowRight
+        }
+        if (userArray[1] !== targetArray[1]){
+            targetWindow.setBattler(targetArray[1])
+        } else if (areaEvents.length > 0){
+            targetWindow.setBattler($gameSystem.EventToUnit(areaEvents[0].eventId())[1])
+        }
+        this.addWindow(this._srpgBattleStatusWindowLeft);
+        this.addWindow(this._srpgBattleStatusWindowRight);
+        BattleManager.setSrpgBattleStatusWindow(this._srpgBattleStatusWindowLeft, this._srpgBattleStatusWindowRight);
+    };
+
+    //helper function
+    Game_Temp.prototype.getAreaEvents = function() {
+        var events = []
+        for (var i = 0; i < this._areaTargets.length; i ++ ) {
+            if (this._areaTargets[i].event) events.push(this._areaTargets[i].event);
+        }
+        return events;
+    };
+    //fix bug for event before battle
+    var _Scene_Map_waitingForSkill = Scene_Map.prototype.waitingForSkill
+    Scene_Map.prototype.waitingForSkill = function() {
+        if ($gameMap.isEventRunning()){
+            return true;
+        }
+        return _Scene_Map_waitingForSkill.call(this);
+    };
+
+    // fix bug for not clearing area after searching targets.
+    var _Scene_Map_prototype_srpgAICommand = Scene_Map.prototype.srpgAICommand
+    Scene_Map.prototype.srpgAICommand = function() {
+        var result = _Scene_Map_prototype_srpgAICommand.call(this);
+        if (!result){
+            $gameTemp.clearAreaTargets();
+            $gameTemp.clearArea();
+        }
+        return result;
+    };
+
+    var _Game_Action_apply = Game_Action.prototype.apply
+    Game_Action.prototype.apply = function(target) {
+        if ($gameSystem.useMapBattle() && $gameSystem.isSubBattlePhase() == 'invoke_action'){
+            var result = target.result();
+            result.clear();
+            result.used = this.testApply(target);
+            result.missed = (result.used && Math.random() >= this.itemHit(target));
+            result.evaded = (!result.missed && Math.random() < this.itemEva(target));
+            result.physical = this.isPhysical();
+            result.drain = this.isDrain();
+            if (result.isHit()) {
+                if (this.item().damage.type > 0) {
+                    result.critical = (Math.random() < this.itemCri(target));
+                    var value = this.makeDamageValue(target, result.critical);
+                    this.executeDamage(target, value);
+                }
+                this.item().effects.forEach(function(effect) {
+                    this.applyItemEffect(target, effect);
+                }, this);
+                this.applyItemUserEffect(target);
+            }
+        } else {
+            _Game_Action_apply.call(this, target);
+        }
+    };
+
+    // damage pop-up with less computation
+    Sprite_Character.prototype.setupDamagePopup_MB = function() {
+        var array = $gameSystem.EventToUnit(this._character.eventId());
+        if ($gameSystem.isSRPGMode() && array && array[1]) {
+            var battler = array[1];
+            if (battler.isDamagePopupRequested()) {
+                var sprite = new Sprite_Damage();
+                sprite.x = this.x;
+                sprite.y = this.y;
+                sprite.z = 9;
+                sprite.setup(battler);
+                this._damages.push(sprite);
+                this.parent.addChild(sprite);
+                battler.clearDamagePopup();
+                battler.clearResult();
+            }
+        }
+    };
+// ==========================================================================
+// repeated AoE action that doesn't show animation and doesn't cost tp, mp
+// ==========================================================================
+    Game_Action.prototype.setHideAnimation = function(val){
+        this._hideAnimation = val;
+    }
+    //only work with my bugfixed srpg_DynamicAction
+    Game_Action.prototype.isHideAnimation = function(){
+        return this._hideAnimation;
+    }
+
+    Game_Action.prototype.setEditedItem = function(item){
+        this._editedItem = item;
+    }    
+
+    // set up Action that and item that has no animation and no cost for repetation
+    Game_Action.prototype.createAoERepeatedAction = function(){
+        var hiddenAction = new Game_Action(this.subject());
+        var noCostItem = {
+            ...this.item()
+        }
+        noCostItem.mpCost = 0;
+        noCostItem.tpCost = 0;
+        noCostItem.srpgDataClass = this._item._dataClass;
+        hiddenAction.setItemObject(this.item());
+        hiddenAction.setEditedItem(noCostItem);
+        hiddenAction.setHideAnimation(true);
+        return hiddenAction;
+    }    
+
+    var _Game_Action_item = Game_Action.prototype.item;
+    Game_Action.prototype.item = function() {
+        if (this._editedItem) return this._editedItem;
+        return _Game_Action_item.call(this);
+    };
+
+    Game_Action.prototype.canAgiAttack = function(action){
+        return this.isForOpponent() && !this.item().meta.doubleAction;
+    }
+
+//============================================================================================
+//A hack way to get AoE counter attack distance correct.
+//============================================================================================
+    Game_Battler.prototype.setAoEDistance = function(val){
+        this._AoEDistance = val;
+    }
+
+    Game_Battler.prototype.AoEDistance = function(){
+        return this._AoEDistance;
+    }
+
+    Game_Battler.prototype.clearAoEDistance = function(){
+        this._AoEDistance = undefined;
+    }
+
+    //let our faked skill item considered as skill
+    var _DataManager_isSkill = DataManager.isSkill;
+    DataManager.isSkill = function(item) {
+        return _DataManager_isSkill.call(this, item) || (item && item.srpgDataClass === 'skill');
+    };
+
+    //A hack way to get skill correct.
+    var _Game_Actor_srpgSkillMinRange = Game_Actor.prototype.srpgSkillMinRange
+    Game_Actor.prototype.srpgSkillMinRange = function(skill) {
+        var range = _Game_Actor_srpgSkillMinRange.call(this, skill);
+        if (this.AoEDistance() !== undefined) return this.AoEDistance() >= range ? -1 : 99;
+        else return range;
+    };
+
+    var _Game_Enemy_srpgSkillMinRange = Game_Enemy.prototype.srpgSkillMinRange
+    Game_Enemy.prototype.srpgSkillMinRange = function(skill) {
+        var range = _Game_Enemy_srpgSkillMinRange.call(this, skill);
+        if (this.AoEDistance() !== undefined) return this.AoEDistance() >= range ? -1 : 99;
+        else return range;
+    };
+
+    var _Game_Actor_srpgSkillRange = Game_Actor.prototype.srpgSkillRange
+    Game_Actor.prototype.srpgSkillRange = function(skill) {
+        var range = _Game_Actor_srpgSkillRange.call(this, skill);
+        if (this.AoEDistance() !== undefined) return this.AoEDistance() > range ? -1 : 99;
+        else return range;
+    };
+
+    var _Game_Enemy_srpgSkillRange = Game_Enemy.prototype.srpgSkillRange
+    Game_Enemy.prototype.srpgSkillRange = function(skill) {
+        var range = _Game_Enemy_srpgSkillRange.call(this, skill);
+        //console.log(this, range)
+        if (this.AoEDistance() !== undefined) return this.AoEDistance() > range ? -1 : 99;
+        else return range;
+    };
+
+//==========================================================================================================
+// Exp distribution,  turn end condition fix.
+//==========================================================================================================
+    //End turn immediately when active battler is dead.
+    var _BattleManager_updateTurn = BattleManager.updateTurn
+    BattleManager.updateTurn = function() {
+        if ($gameSystem.isSRPGMode()){
+            if ($gameSystem.EventToUnit($gameTemp.activeEvent().eventId())[1].isDead()){
+                this.endTurn();
+            }
+        }
+        _BattleManager_updateTurn.call(this)
+    };
+
+    var _SRPG_BattleManager_endTurn = BattleManager.endTurn;
+    BattleManager.endTurn = function() {
+        if ($gameSystem.isSRPGMode() == true) {
+            this._phase = 'battleEnd';
+            this._preemptive = false;
+            this._surprise = false;
+            this.refreshStatus();
+            if (this._phase) {
+                if ($gameParty.battleMembers().length > 0 && !$gameParty.isAllDead()) { // edit so gain exp when there are live members
+                    this.processSrpgVictory();
+                } else {
+                    this.endBattle(3);
+                }
+            }
+        } else {
+            _SRPG_BattleManager_endTurn.call(this);
+        }
+    };
+
+    BattleManager.battlerDeadEndBattle = function() {
+        var userType = $gameSystem.EventToUnit($gameTemp.activeEvent().eventId())[0]
+        var targetType = $gameSystem.EventToUnit($gameTemp.targetEvent().eventId())[0]
+        if ($gameSystem.EventToUnit($gameTemp.activeEvent().eventId())[1].isDead()){
+            return true;
+        }
+        if (userType == targetType) return false;
+        return $gameParty.isAllDead() || $gameTroop.isAllDead();
+    }
+
+    Scene_Map.prototype.battlerDeadEndBattle = BattleManager.battlerDeadEndBattle;
+
+    //share exp when enemy cast AoE to multiple actors
+    var _SRPG_BattleManager_gainExp = BattleManager.gainExp;
+    BattleManager.gainExp = function() {
+        if (BattleManager.shareExp()) {
+            var exp = Math.round(this._rewards.exp / $gameParty.battleMembers().length)
+            //console.log( $gameParty.battleMembers());
+            $gameParty.battleMembers().forEach(function(actor) {
+                actor.gainExp(exp);
+            });
+        } else {
+            _SRPG_BattleManager_gainExp.call(this);
+        }
+    };
+
+   //add aoe target exp
+    var _SRPG_Game_Troop_expTotal = Game_Troop.prototype.expTotal;
+    Game_Troop.prototype.expTotal = function() {
+        if ($gameSystem.isSRPGMode() == true) {
+            var activeArray = $gameSystem.EventToUnit($gameTemp.activeEvent().eventId());
+            var exp = 0;
+            if (activeArray[0] == 'enemy'){
+                exp += (activeArray[1].isDead() ? activeArray[1].exp() : activeArray[1].exp() * _srpgBattleExpRate);
+            } else if (this.SrpgBattleEnemys() && this.SrpgBattleEnemys().length > 0) {
+                for (var i = 0; i < this.members().length; i++) {
+                    var enemy = this.members()[i];
+                    exp += (enemy.isDead() ? enemy.exp() : enemy.exp() * _srpgBattleExpRate);
+                }
+            } else {
+                var actor = $gameParty.battleMembers()[0];
+                exp += (actor.nextLevelExp() - actor.currentLevelExp()) * _srpgBattleExpRateForActors;
+            }
+            return Math.round(exp);
+        } else return _SRPG_Game_Troop_expTotal.call(this);
+    };
+
+    //condition to share exp
+    BattleManager.shareExp = function(){
+        return $gameSystem.isSRPGMode() == true && $gameSystem.EventToUnit($gameTemp.activeEvent().eventId())[0] != 'actor';
+    }
+
+    Scene_Map.prototype.gainExp = BattleManager.gainExp;
+
+    //add check for whether AoE map battle is finished.
+    Scene_Map.prototype.processSrpgVictory = function() {
+        var members = $gameParty.aliveMembers();
+        if (members.length > 0) {
+            this.makeRewards();
+            if (this.hasRewards()) {
+                this._srpgBattleResultWindow.setBattler(members[0]);
+                this._srpgBattleResultWindow.setRewards(this._rewards);
+                var se = {};
+                se.name = _rewardSe;
+                se.pan = 0;
+                se.pitch = 100;
+                se.volume = 90;
+                AudioManager.playSe(se);
+                this._srpgBattleResultWindow.open();
+                this.gainRewards();
+                //this.initRewards();
+                return true;
+            }
+        }
+        return false;
+    };
+
+    Scene_Map.prototype.hasRewards = function() {
+        return this._rewards.exp > 0 || this._rewards.gold > 0 || this._rewards.items.length > 0;
+    }
+
+//==========================================================================================================
+// Map battle log window
+//==========================================================================================================
+    var _SRPG_SceneMap_createAllWindows = Scene_Map.prototype.createAllWindows;
+    Scene_Map.prototype.createAllWindows = function() {
+        this.createLogWindow();
+        _SRPG_SceneMap_createAllWindows.call(this);
+    };
+
+    Scene_Map.prototype.createLogWindow = function() {
+        this._logWindow = new Window_BattleLog();
+        this.addWindow(this._logWindow);
+        this._logWindow.hide();
+    };
+
+    var _Scene_Map_srpgAfterAction = Scene_Map.prototype.srpgAfterAction;
+    Scene_Map.prototype.srpgAfterAction = function() {
+        this._logWindow.clear();
+        this._logWindow.hide();
+        _Scene_Map_srpgAfterAction.call(this);
+    };
+
+//==========================================================================================================
+// Srpg Battle Result window that can display more items and show exp according to the new distribution rule
+//==========================================================================================================
+
+    // if active event is not actor, distribute exp to all battle members.
+    Window_SrpgBattleResult.prototype.setRewards = function(rewards) {
+        this._rewards = {}
+        this._rewards.gold = rewards.gold;
+        this._rewards.items = rewards.items;
+        if (BattleManager.shareExp()){
+            this._rewards.exp = Math.round(rewards.exp / $gameParty.battleMembers().length);
+        } else {
+            this._rewards.exp = rewards.exp
+        }
+        this._changeExp = 30;
+    };
+
+    //change the way to draw items to support multiple items.
+    Window_SrpgBattleResult.prototype.drawGainItem = function(x, y) {
+        // I really wants to use hash map here but seems like not everyone has ES6 JS.
+        var counts = [];
+        var searched = [];
+        for (var i = 0; i < this._rewards.items.length; i ++){
+            var item = this._rewards.items[i];
+            var idx = searched.indexOf(item);
+            if (idx < 0){
+                searched.push(item);
+                counts.push(1);
+            } else {
+                counts[idx] += 1;
+            }
+        }
+        var width = (this.windowWidth() - this.padding * 2) / 2 - this.textWidth('XXXX');
+        for (var i = 0; i < searched.length; i++) {
+            var posX = x + width * Math.floor(0.5 + i * 0.5);
+            var posY = y - this.lineHeight() * (i % 2);
+            var iconWidth = Window_Base._iconWidth + 4;
+            var nameWidth = this.textWidth(searched[i].name);
+            var numberX = Math.min(iconWidth + nameWidth, width) + this.textWidth('X') + this.textPadding();
+            this.drawItemName(searched[i], posX, posY, width);
+            this.drawItemNumber(counts[i], posX + numberX, posY, this.textWidth('XXX') + this.textPadding());
+        }
+    }
+
+    Window_SrpgBattleResult.prototype.drawItemNumber = function(counts, x, y, width) {
+        if (counts < 2) return;
+        this.changeTextColor(this.systemColor());
+        this.drawText('X', x, y, width, 'left');
+        this.drawText(counts, x + this.textWidth('X') + this.textPadding(), y, width - this.textWidth('X'), 'left');
+    };
+
+    // var _Game_Interpreter_updateWaitMode = Game_Interpreter.prototype.updateWaitMode;
+    // Game_Interpreter.prototype.updateWaitMode = function() {
+    //     if (this._waitMode == "animation") {
+    //         if (!this._character) return false
+    //     }
+    //     return _Game_Interpreter_updateWaitMode.apply(this, arguments);;
+    // };
+
+    // var _SRPG_MB_SceneMap_update = Scene_Map.prototype.update;
+    // Scene_Map.prototype.update = function() {
+    //     if ($gameSystem.isSubBattlePhase() == 'invoke_action' && $gameMap.isEventRunning()){
+    //         return;
+    //     }
+    //     _SRPG_MB_SceneMap_update.call(this);
+    // }
+
+
+    // BattleManager.makeRewards = function() {
+    //     this._rewards.gold = $gameTroop.goldTotal();
+    //     this._rewards.exp = $gameTroop.expTotal();
+    //     this._rewards.items = $gameTroop.makeDropItems();
+    // };
+    // this is a single target version, it can be generalized to AoE targets so this is just for backup.
+    // Scene_Map.prototype.processSceneBattle = function(userArray, targetArray){
+    //     var userType = userArray[0];
+    //     var user = userArray[1];
+    //     var targetType = targetArray[0];
+    //     var target = targetArray[1];
+    //     $gameParty.clearSrpgBattleActors();
+    //     $gameTroop.clearSrpgBattleEnemys();
+
+    //     this.pushSrpgBattler(userType, user);
+    //     if (userType === 'enemy') user.action(0).setSrpgEnemySubject(0);
+    //     //console.log(user === target);
+    //     if (user === target){
+    //         user.action(0).setTarget(0);
+    //     } else if (userType === targetType) {
+    //         this.pushSrpgBattler(targetType, target);
+    //         user.action(0).setTarget(1);
+    //     } else {
+    //         this.pushSrpgBattler(targetType, target);
+    //         user.action(0).setTarget(0);            
+    //     }
+
+    //     user.setActionTiming(0);
+    //     BattleManager.setup($dataTroops[_srpgTroopID] ? _srpgTroopID : 1, false, true);
+
+    //     //対象の行動を設定
+    //     if (userType !== targetType && target.canMove() && !user.currentAction().item().meta.srpgUncounterable) {
+    //         target.srpgMakeNewActions();
+    //         if (targetType === 'enemy') target.action(0).setSrpgEnemySubject(0);
+    //         target.action(0).setAttack();
+    //         target.action(0).setTarget(0);
+    //         target.setActionTiming(1);
+    //     }
+
+    //     this.preBattleSetDirection();
+    //     //行動回数追加スキルなら行動回数を追加する
+    //     var addActionNum = Number(user.action(0).item().meta.addActionTimes);
+    //     if (addActionNum && addActionNum > 0) {
+    //         user.SRPGActionTimesAdd(addActionNum);
+    //     }
+    //     this._callSrpgBattle = true;
+    //     this.eventBeforeBattle();
+    // }
+
+})();

--- a/SRPG_DynamicAction.js
+++ b/SRPG_DynamicAction.js
@@ -1,0 +1,745 @@
+//-----------------------------------------------------------------------------
+// SRPG_DynamicAction.js
+// Copyright (c) 2020 SRPG Team. All rights reserved. This is a Shoukang Fixed version
+// Released under the MIT license.
+// http://opensource.org/licenses/mit-license.php
+//=============================================================================
+
+/*:
+ * @target MV
+ * @plugindesc v1.00 Call DynamicAnimationMap and MotionMap during SRPG map battle
+ * @author  SRPG Team
+ * @base SRPG_core
+ * @orderAfter SRPG_core
+ * @orderAfter SRPG_AoE
+ * @orderAfter NRP_DynamicAnimation
+ * @orderAfter NRP_DynamicAnimationMap
+ *
+ * @help Call DynamicAnimationMap and DynamicMotionMap
+ * when SRPG_core.js map battle is executed.
+ *
+ * Shoukang's fix: when casting and on map AoE, counter attacks now show up correctly. Add battle log compatibility with AoE animation plugin
+ * 
+ * [Based on works by Takeshi Sunagawa (http://newrpg.seesaa.net/)]
+ *
+ * You need the following plugins to use it.
+ * - SRPG_core.js
+ * - SRPG_AoE.js
+ * - MRP_DynamicAnimation.js
+ * - MRP_DynamicAnimationMap.js
+ * 
+ * Also, this plugin should be placed below the following plugins.
+ * - SRPG_core.js
+ * - SRPG_AoE.js
+ * - NRP_DynamicAnimation.js
+ * - NRP_DynamicAnimationMap.js
+ * 
+ * ==========Plugin parameter details==========
+ * ◆Batch execution of actions
+ * If you turn it on, it will do all actions first
+ * and show damage later in batches.
+ * This allows for a high degree of flexibility in staging.
+ * Note, however, that the production will no longer be affected
+ * by the magic reflection process.
+ * 
+ * For each skill, you can switch by filling in the note below.
+ * <D-Setting:BatchActionOn>
+ * <D-Setting:BatchActionOff>
+ * 
+ * ==========Cooperation with area effects==========
+ * SRPG_AoE.js area effects are also supported.
+ * If you set a skill to an animation with a position of 'screen',
+ * the action will be performed towards the center of the selected area.
+ * 
+ * You can also specify a "whole" template to force a position to "screen".
+ * For example, set the skill to a single animation and do the following
+ * 
+ * ---------------------------------
+ * <srpgRange:3>
+ * <srpgAreaRange:3>
+ *
+ * <D-Motion:crash&jump&whole/>
+ * <D-Animation:whole&wait>
+ * id = 88
+ * </D-Animation>
+ * <D-Animation>
+ * id = 86
+ * </D-Animation>
+ * <D-Motion:return/>
+ * ---------------------------------
+ * 
+ * The actor moves to the center of the area and performs 88 animation.
+ * A further 86 animation should be executed for each target.
+ * 
+ * ==========Damage indication==========
+ * DynamicAnimation and Motion damage display features are available.
+ * For example, the following will show damage in the middle of an action.
+ * 
+ * <D-Animation:damage/>
+ * 
+ * However, due to specification restrictions,
+ * if there are multiple targets in an area effect,
+ * only the first one will work. Please note.
+ * 
+ * ==========<directionalAnimation>==========
+ * You can also use the <directionalAnimation> feature in SRPG_core.js,
+ * but the usage is a little different.
+ * 
+ * <directionalAnimation:20> changes the animation
+ * for ID=20 used in <D-Animation>.
+ * 
+ * <directionalAnimation:10,20> Multiple specifications are possible.
+ * <directionalAnimation> If no ID is specified, all animations are targeted.
+ * 
+ * [Terms]
+ * Released under the MIT license.
+ * http://opensource.org/licenses/mit-license.php
+ * 
+ * @param BatchAction
+ * @type boolean
+ * @default true
+ * @desc Execute actions in batches and postpone the damage display.
+ * If it's off, the behavior is in line with SRPG_core standards.
+ * 
+ * @param DamageInterval
+ * @type number
+ * @default 30
+ * @desc The damage display interval for skills that are set to repeat.
+ * This only applies when "BatchAction" is on.
+ */
+
+/*:ja
+ * @target MV
+ * @plugindesc v1.00 SRPGマップ戦闘時、DynamicAnimationMap&MotionMapを呼び出します。
+ * @author 砂川赳（http://newrpg.seesaa.net/）
+ * @base SRPG_core
+ * @orderAfter SRPG_core
+ * @orderAfter SRPG_AoE
+ * @orderAfter NRP_DynamicAnimation
+ * @orderAfter NRP_DynamicAnimationMap
+ *
+ * @help SRPG_core.jsのマップ戦闘実行時に
+ * DynamicAnimationMapおよびDynamicMotionMapを呼び出します。
+ * 
+ * 使用には以下のプラグインが必要です。
+ * - SRPG_core.js
+ * - MRP_DynamicAnimation.js
+ * - MRP_DynamicAnimationMap.js
+ * 
+ * また、このプラグインは以下のプラグインよりも下に配置してください。
+ * - SRPG_core.js
+ * - SRPG_AoE.js
+ * - NRP_DynamicAnimation.js
+ * - NRP_DynamicAnimationMap.js
+ * 
+ * ==========プラグインパラメータの詳細==========
+ * ◆アクションを一括実行
+ * オンにすると先に全てのアクションを行い、後でまとめてダメージ表示をするようになります。
+ * これにより自由度の高い演出が可能となります。
+ * ただし、演出が魔法反射処理の影響を受けなくなるので注意してください。
+ * 
+ * スキル毎に、以下をメモ欄に記入すれば切替も可能です。
+ * <D-Setting:BatchActionOn>
+ * <D-Setting:BatchActionOff>
+ * 
+ * ==========エリア効果との連携==========
+ * SRPG_AoE.jsによるエリア効果にも対応しています。
+ * 位置が『画面』のアニメーションをスキルに設定すると、
+ * 選択エリアの中央に向かってアクションが実行されるようになります。
+ * 
+ * また『whole』テンプレートを指定すれば、強制的に位置を『画面』に変更できます。
+ * 例えば、スキルに単体向けのアニメーションを設定して以下を実行してください。
+ * 
+ * ---------------------------------
+ * <srpgRange:3>
+ * <srpgAreaRange:3>
+ *
+ * <D-Motion:crash&jump&whole/>
+ * <D-Animation:whole&wait>
+ * id = 88
+ * </D-Animation>
+ * <D-Animation>
+ * id = 86
+ * </D-Animation>
+ * <D-Motion:return/>
+ * ---------------------------------
+ * 
+ * アクターがエリアの中央に移動して、88のアニメーションを実行。
+ * さらに86のアニメーションを各対象に向けて実行するという流れになるはずです。
+ * 
+ * ==========ダメージ表示==========
+ * DynamicAnimationおよびMotionのダメージ表示機能が使用できます。
+ * 例えば、下記のように指定すれば、アクションの途中でもダメージが表示されます。
+ * 
+ * <D-Animation:damage/>
+ * 
+ * ただし、仕様上の制約によりエリア効果で複数の対象がある場合は、
+ * 最初の１体しか機能しません。ご注意ください。
+ * 
+ * ==========<directionalAnimation>==========
+ * SRPG_core.jsの<directionalAnimation>機能も使用可能ですが、
+ * 使い方が少し異なります。
+ * 
+ * <directionalAnimation:20> と設定した場合、
+ * <D-Animation>内で使用されているID=20のアニメーションが変化します。
+ * 
+ * <directionalAnimation:10,20> というように複数指定も可能です。
+ * <directionalAnimation> IDの指定がない場合、全アニメーションを対象とします。
+ * 
+ * ■利用規約
+ * 当プラグインはMITライセンスに基づき公開されています。
+ * http://opensource.org/licenses/mit-license.php
+ * 
+ * @param BatchAction
+ * @text アクションを一括実行
+ * @type boolean
+ * @default true
+ * @desc アクションを一括で実行し、ダメージ表示を後回しにします。
+ * オフならSRPG_coreの標準に沿った動作になります。
+ * 
+ * @param DamageInterval
+ * @text ダメージ表示間隔
+ * @type number
+ * @default 30
+ * @desc 連続回数が設定されているスキルのダメージ表示間隔です。
+ * 『アクションを一括実行』がオンの場合のみ適用されます。
+ */
+(function() {
+"use strict";
+
+function toBoolean(val, def) {
+    if (val === "" || val === undefined) {
+        return def;
+        
+    } else if (typeof val === "boolean") {
+        return val;
+    }
+    return val.toLowerCase() == "true";
+}
+function toNumber(str, def) {
+    return isNaN(str) ? def : +(str || def);
+}
+
+const parameters = PluginManager.parameters("SRPG_DynamicAction");
+const _batchAction = toBoolean(parameters["BatchAction"], true);
+const _damageInterval = toNumber(parameters["DamageInterval"], 30);
+
+const srpgCoreParameters = PluginManager.parameters('SRPG_core');
+const _animDelay = Number(srpgCoreParameters['Animation Delay'] || -1);
+
+/**
+ * ●invoke skill effects
+ * ※Function of SRPG_Core.
+ */
+const _Scene_Map_srpgInvokeMapSkill = Scene_Map.prototype.srpgInvokeMapSkill;
+Scene_Map.prototype.srpgInvokeMapSkill = function(data) {
+    const action = data.action;
+    const item = action.item();
+    const interpreter = $gameMap._interpreter;
+    interpreter.dynamicNoWaitControl = undefined;
+    const user = data.user;
+    const target = data.target;
+    var animation = item.animationId;
+    //shoukang get animation id right
+    if (animation < 0) animation = (user.isActor() ? user.attackAnimationId1() : user.attackAnimationId());
+    if (!action.isDynamicAnimation(animation) && action.area() <= 0) {
+
+        //shoukang edit to show battle log
+        if (data.phase == 'start') {
+            if (!user.canMove() || !user.canUse(action.item()) || this.battlerDeadEndBattle()) {
+                data.phase = 'cancel';
+                this._srpgSkillList.unshift(data);
+                // Show the results
+                return srpgInvokeMapSkillResult(user, target);
+            }
+            if (!action._editedItem){
+                this._logWindow.show();
+                this._logWindow.displayAction(user, action.item());
+            }
+        }
+
+        return _Scene_Map_srpgInvokeMapSkill.apply(this, arguments);
+    }
+
+    // start
+    if (data.phase == 'start' && action.isBatchAction()) {
+        if (!user.canMove() || !user.canUse(action.item()) || this.battlerDeadEndBattle()) {
+            data.phase = 'cancel';
+            this._srpgSkillList.unshift(data);
+            // Show the results
+            return srpgInvokeMapSkillResult(user, target);
+        }
+
+        //shoukang edit to show battle log
+        user.useItem(action.item());
+        if (!action._editedItem){
+            this._logWindow.show();
+            this._logWindow.displayAction(user, action.item());
+        }
+
+        //shoukang add condition check
+        var targetsEventId = undefined;
+        //aoe
+        if (user.event() == $gameTemp.activeEvent() && !action.isHideAnimation()) {
+            targetsEventId = makeTargetsEventIdInArea($gameTemp.originalAreaTargets(), target, data.count);
+        } else if (!action.isHideAnimation()){ // not AoE
+            targetsEventId = [target.event().eventId()];
+        }
+
+        if (targetsEventId){
+            interpreter.pluginCommand("nrp.animation.wait", []);
+            interpreter.pluginCommand("nrp.animation.subject", [user.event().eventId()]);
+            // A subject battler used to reference normal attacks, etc.
+            interpreter.pluginCommand("nrp.animation.subjectBattler", [user]);
+
+            interpreter.pluginCommand("nrp.animation.target", [targetsEventId]);
+            if (action.isItem()) {
+                interpreter.pluginCommand("nrp.animation.item", [item.id]);
+            } else {
+                interpreter.pluginCommand("nrp.animation.skill", [item.id]);
+            }
+
+            // time-based delay
+            this.setDynamicSkillWait(item, interpreter);
+
+            var castAnim = false;
+            // cast animation, is a skill, isn't an attack or guard
+            if (action.item().castAnimation && action.isSkill() && !action.isAttack() && !action.isGuard()) {
+                user.event().requestAnimation(action.item().castAnimation);
+                castAnim = true;
+            }
+            // target animation
+            if (action.item().meta.targetAnimation) {
+                $gamePlayer.requestAnimation(Number(action.item().meta.targetAnimation));
+                castAnim = true;
+            }
+        }
+
+        // check for reflection
+        if (user != target && Math.random() < action.itemMrf(target)) {
+            data.phase = 'reflect';
+        } else {
+            data.phase = 'animation';
+        }
+        data.isFirstEffect = true;
+        this._srpgSkillList.unshift(data);
+
+        // Show the results
+        return srpgInvokeMapSkillResult(user, target);
+
+    // show skill animation
+    } else if (data.phase == 'animation') {
+        if (!action.isBatchAction()) {
+            // Call NRP_DynamicAnimationMap.js
+            interpreter.pluginCommand("nrp.animation.wait", []);
+            interpreter.pluginCommand("nrp.animation.subject", [user.event().eventId()]);
+            // A subject battler used to reference normal attacks, etc.
+            interpreter.pluginCommand("nrp.animation.subjectBattler", [user]);
+            interpreter.pluginCommand("nrp.animation.target", [target.event().eventId()]);
+            if (action.isItem()) {
+                interpreter.pluginCommand("nrp.animation.item", [item.id]);
+            } else {
+                interpreter.pluginCommand("nrp.animation.skill", [item.id]);
+            }
+
+            // time-based delay
+            this.setDynamicSkillWait(item, interpreter);
+
+        // Set damage interval
+        } else {
+            // Wait for all but the first time.
+            if (!data.isFirstEffect) {
+                this.setSkillWait(_damageInterval);
+            }
+            data.isFirstEffect = undefined;
+        }
+
+        data.phase = 'effect';
+        this._srpgSkillList.unshift(data);
+        
+        // Show the results
+        return srpgInvokeMapSkillResult(user, target);
+
+    // reflected magic
+    } else if (data.phase == 'reflect') {
+        target.performReflection();
+        if (target.reflectAnimationId && !action.isBatchAction()) {
+            // Call NRP_DynamicAnimationMap.js
+            interpreter.pluginCommand("nrp.animation.wait", []);
+            interpreter.pluginCommand("nrp.animation.subject", [user.event().eventId()]);
+            // Set target user
+            interpreter.pluginCommand("nrp.animation.target", [user.event().eventId()]);
+            // A subject battler used to reference normal attacks, etc.
+            interpreter.pluginCommand("nrp.animation.subjectBattler", [user]);
+            if (action.isItem()) {
+                interpreter.pluginCommand("nrp.animation.item", [item.id]);
+            } else {
+                interpreter.pluginCommand("nrp.animation.skill", [item.id]);
+            }
+        }
+
+        data.target = user;
+        data.phase = 'animation';
+        this._srpgSkillList.unshift(data);
+
+        // Show the results
+        return srpgInvokeMapSkillResult(user, target);
+    }
+
+    return _Scene_Map_srpgInvokeMapSkill.apply(this, arguments);
+};
+
+/**
+ * ●Adjusting skill wait for DynamicAction
+ */
+Scene_Map.prototype.setDynamicSkillWait = function(item, interpreter) {
+    // time-based delay
+    var delay = _animDelay;
+    if (item.meta.animationDelay) delay = Number(item.meta.animationDelay);
+    if (delay >= 0) {
+        this.setSkillWait(delay);
+        // Wait control is not performed on the DynamicAction side.
+        interpreter.dynamicNoWaitControl = true;
+    }
+}
+
+/**
+ * ●エリア内のイベントを元に、DynamicAnimationMap用の対象を取得する。
+ * ●Make targets for the DynamicAnimationMap based on the events in the area.
+ */
+function makeTargetsEventIdInArea(areaTargets, target, count) {
+    let targetsEventId = "";
+    // Consider Repeat
+    for (let i = 0; i < count; i++) {
+        // area
+        if (areaTargets.length > 0) {
+            // connect targets ID
+            for (const areaAction of areaTargets) {
+                if (targetsEventId.length > 0) {
+                    targetsEventId += ",";
+                }
+                targetsEventId += areaAction.event.eventId();
+            }
+        // single
+        } else {
+            if (targetsEventId.length > 0) {
+                targetsEventId += ",";
+            }
+            targetsEventId += target.event().eventId();
+        }
+    }
+    return targetsEventId;
+}
+
+/**
+ * ●Show the results
+ */
+function srpgInvokeMapSkillResult(user, target) {
+    user.srpgShowResults();
+    target.srpgShowResults();
+    return true;
+}
+
+/**
+ * ●check if we're still waiting for a skill to finish
+ * ※Function of SRPG_Core.
+ */
+const _Scene_Map_waitingForSkill = Scene_Map.prototype.waitingForSkill;
+Scene_Map.prototype.waitingForSkill = function() {
+    const result = _Scene_Map_waitingForSkill.apply(this, arguments);
+    const interpreter = $gameMap._interpreter;
+
+    // Wait control is not performed on the DynamicAction side.
+    if (interpreter.dynamicNoWaitControl) {
+        return result;
+
+    // Wait for DynamicAnimation
+    } else if (interpreter.isDynamicAnimationPlaying()) {
+        if (interpreter.dynamicDuration > 0) {
+            interpreter.dynamicDuration--;
+        }
+        return true;
+    }
+
+    return result;
+};
+
+const _Game_Temp_initialize = Game_Temp.prototype.initialize;
+Game_Temp.prototype.initialize = function() {
+    _Game_Temp_initialize.call(this);
+    this._originalAreaTargets = [];
+};
+
+/**
+ * ※Function of SRPG_AoE.js
+ */
+const _Game_Temp_clearAreaTargets = Game_Temp.prototype.clearAreaTargets;
+Game_Temp.prototype.clearAreaTargets = function() {
+    _Game_Temp_clearAreaTargets.apply(this, arguments);
+
+    this._originalAreaTargets = [];
+};
+
+/**
+ * ※Function of SRPG_AoE.js
+ */
+// Find all the targets within the current AoE
+const _Game_Temp_selectArea  = Game_Temp.prototype.selectArea;
+Game_Temp.prototype.selectArea = function(user, skill) {
+    const originalResult = _Game_Temp_selectArea.apply(this, arguments);
+
+    // Since the contents of areaTargets are shifted, the initial value is retained.
+    if (originalResult) {
+        this._originalAreaTargets = this.areaTargets().clone();
+    }
+
+    return originalResult;
+}
+
+/**
+ * 【New】Original targets in the area.
+ */
+Game_Temp.prototype.originalAreaTargets = function() {
+    return this._originalAreaTargets;
+};
+
+/**
+ * 【New】Whether or not to execute the performance in batches?
+ */
+Game_Action.prototype.isBatchAction = function() {
+    if (this.existDynamicSetting("BatchActionOn")) {
+        return true;
+    } else if (this.existDynamicSetting("BatchActionOff")) {
+        return false;
+    } else if (_batchAction) {
+        return true;
+    }
+    return false;
+};
+
+/**
+ * ●Get a character or a follower.
+ * ※Function of NRP_DynamicAnimationMap
+ */
+const _Game_Interpreter_characterAndFollower = Game_Interpreter.prototype.characterAndFollower;
+Game_Interpreter.prototype.characterAndFollower = function(param) {
+    const result = _Game_Interpreter_characterAndFollower.apply(this, arguments);
+
+    // If the original result is null and useMapBattle, retrieve the value.
+    // workaround for this.isOnCurrentMap() to be false.
+    if (result == null && $gameSystem.useMapBattle()) {
+        return $gameMap.event(param > 0 ? param : this._eventId);
+    }
+};
+
+/**
+ * 【New】Define an alias for attackAnimationId1 as well, to be referenced from DynamicAnimation.
+ */
+Game_Enemy.prototype.attackAnimationId1 = function() {
+    return this.attackAnimationId();
+};
+
+/**
+ * ●アニメーションデータを取得する。
+ * ※Function of NRP_DynamicAnimationMap
+ */
+const _BaseAnimation_getAnimation = BaseAnimation.prototype.getAnimation;
+BaseAnimation.prototype.getAnimation = function (id) {
+    const action = this.action;
+
+    // directional target animation
+    const directionalAnimation = action.item().meta.directionalAnimation;
+    // Case <directionalAnimation>
+    if (directionalAnimation === true) {
+        const dir = this.action.subject().event().direction() / 2 - 1;
+        id = dir + Number(id);
+
+    // Case <directionalAnimation:x>
+    } else if (directionalAnimation) {
+        // Verify the existence of each comma-separated value.
+        const isDirectional = directionalAnimation.split(",").some(function(directionalId) {
+            return directionalId == id;
+        });
+
+        if (isDirectional) {
+            const dir = this.action.subject().event().direction() / 2 - 1;
+            id = dir + Number(id);
+        }
+    }
+
+    return _BaseAnimation_getAnimation.call(this, id);
+};
+
+/**
+ * ●DynamicAnimationの途中でダメージ制御を行う
+ * ※Function of NRP_DynamicAnimation
+ */
+const _BattleManager_dynamicDamageControl = BattleManager.dynamicDamageControl;
+BattleManager.dynamicDamageControl = function(dynamicAction) {
+    if ($gameSystem.useMapBattle()) {
+        // I don't make a distinction between damage and damageAll.
+        if (dynamicAction.damage || dynamicAction.damageAll) {
+            // Instant damage display.
+            const scene = SceneManager._scene;
+            const srpgSkillList = scene._srpgSkillList || [];
+            const data = srpgSkillList[0];
+            if (data.count === 0) {
+                return;
+            }
+            data.phase = 'effect';
+            data.isFirstEffect = undefined;
+            srpgSkillList.unshift(data);
+            scene.srpgUpdateMapSkill();
+        }
+        return;
+    }
+
+    _BattleManager_dynamicDamageControl.apply(this, arguments);
+};
+
+/****************************************************
+ * When SRPG_AoE is enabled
+ ****************************************************/
+if (Game_Temp.prototype.areaX) {
+    /**
+     * ●モーション主体から見て直近の対象の隣接Ｘ座標を求める
+     * ※Function of NRP_DynamicAnimationMap
+     */
+    const _Sprite_Character_nearX = Sprite_Character.prototype.nearX;
+    Sprite_Character.prototype.nearX = function(b, position) {
+        // 対象が画面の場合、選択したグリッドを基準にする。
+        // If the target is a screen, it will be based on the selected grid.
+        if (position == 3) {
+            const grid = getGridInfo($gameTemp.areaX(), $gameTemp.areaY());
+            const coordinates = this.getNearCoordinate(grid);
+            return coordinates.x;
+        }
+
+        return _Sprite_Character_nearX.apply(this, arguments);
+    }
+
+    /**
+     * ●モーション主体から見て直近の対象の隣接Ｙ座標を求める
+     * ※Function of NRP_DynamicAnimationMap
+     */
+    const _Sprite_Character_nearY = Sprite_Character.prototype.nearY;
+    Sprite_Character.prototype.nearY = function(b, position) {
+        // 対象が画面の場合、選択したグリッドを基準にする。
+        // If the target is a screen, it will be based on the selected grid.
+        if (position == 3) {
+            const grid = getGridInfo($gameTemp.areaX(), $gameTemp.areaY());
+            const coordinates = this.getNearCoordinate(grid);
+            return coordinates.y;
+        }
+
+        return _Sprite_Character_nearY.apply(this, arguments);
+    }
+
+    /**
+     * ●モーション主体から見て直近の対象の隣接Ｘ座標を求める
+     * ※Function of NRP_DynamicAnimationMap
+     */
+    const _Sprite_Character_crashX = Sprite_Character.prototype.crashX;
+    Sprite_Character.prototype.crashX = function(b, position) {
+        // 対象が画面の場合、選択したグリッドを基準にする。
+        // If the target is a screen, it will be based on the selected grid.
+        if (position == 3) {
+            return $gameMap.mapToCanvasX($gameTemp.areaX());
+        }
+
+        return _Sprite_Character_crashX.apply(this, arguments);
+    }
+
+    /**
+     * ●モーション主体から見て直近の対象の隣接Ｙ座標を求める
+     * ※Function of NRP_DynamicAnimationMap
+     */
+    const _Sprite_Character_crashY = Sprite_Character.prototype.crashY;
+    Sprite_Character.prototype.crashY = function(b, position) {
+        // 対象が画面の場合、選択したグリッドを基準にする。
+        // If the target is a screen, it will be based on the selected grid.
+        if (position == 3) {
+            return $gameMap.mapToCanvasY($gameTemp.areaY()) + $gameMap.tileWidth() / 2;
+        }
+
+        return _Sprite_Character_crashY.apply(this, arguments);
+    }
+
+    /**
+     * ●モーション主体から見て最遠の対象の隣接Ｘ座標を求める
+     * ※Function of NRP_DynamicAnimationMap
+     */
+    const _Sprite_Character_backX = Sprite_Character.prototype.backX;
+    Sprite_Character.prototype.backX = function(b, position) {
+        // 対象が画面の場合、選択したグリッドを基準にする。
+        // If the target is a screen, it will be based on the selected grid.
+        if (position == 3) {
+            const grid = getGridInfo($gameTemp.areaX(), $gameTemp.areaY());
+            const coordinates = this.getBackCoordinate(grid);
+            return coordinates.x;
+        }
+
+        return _Sprite_Character_backX.apply(this, arguments);
+    }
+
+    /**
+     * ●モーション主体から見て最遠の対象の隣接Ｙ座標を求める
+     * ※Function of NRP_DynamicAnimationMap
+     */
+    const _Sprite_Character_backY = Sprite_Character.prototype.backY;
+    Sprite_Character.prototype.backY = function(b, position) {
+        // 対象が画面の場合、選択したグリッドを基準にする。
+        // If the target is a screen, it will be based on the selected grid.
+        if (position == 3) {
+            const grid = getGridInfo($gameTemp.areaX(), $gameTemp.areaY());
+            const coordinates = this.getBackCoordinate(grid);
+            return coordinates.y;
+        }
+
+        return _Sprite_Character_backY.apply(this, arguments);
+    }
+
+    /**
+     * ●標準画面Ｘ座標取得
+     * ※Function of NRP_DynamicAnimation
+     */
+    const _BaseAnimation_getScreenX = BaseAnimation.prototype.getScreenX;
+    BaseAnimation.prototype.getScreenX = function (b) {
+        if ($gameSystem.useMapBattle()) {
+            return $gameMap.mapToCanvasX($gameTemp.areaX());
+        }
+
+        return _BaseAnimation_getScreenX.apply(this, arguments);
+    };
+
+    /**
+     * ●標準画面Ｙ座標取得
+     * ※Function of NRP_DynamicAnimation
+     */
+    const _BaseAnimation_getScreenY = BaseAnimation.prototype.getScreenY;
+    BaseAnimation.prototype.getScreenY = function (b) {
+        if ($gameSystem.useMapBattle()) {
+            return $gameMap.mapToCanvasY($gameTemp.areaY()) + $gameMap.tileWidth() / 2;
+        }
+
+        return _BaseAnimation_getScreenY.apply(this, arguments);
+    };
+}
+
+function getGridInfo(mapX, mapY) {
+    const grid = [];
+    grid.width = $gameMap.tileWidth();
+    grid.height = $gameMap.tileHeight();
+    // マップ座標を画面座標に変換
+    // Convert map coordinates to screen coordinates
+    // ※Function of NRP_DynamicAnimationMap
+    grid.x = $gameMap.mapToCanvasX(mapX);
+    grid.y = $gameMap.mapToCanvasY(mapY) + grid.height / 2;
+    return grid;
+}
+
+Game_Action.prototype.isHideAnimation = function(){
+    return this._hideAnimation;
+}
+
+})();

--- a/SRPG_MapviewBattler.js
+++ b/SRPG_MapviewBattler.js
@@ -1,0 +1,762 @@
+//-----------------------------------------------------------------------------
+// SRPG_MapviewBattler.js
+// Copyright (c) 2020 SRPG Team. All rights reserved.
+// Released under the MIT license.
+// http://opensource.org/licenses/mit-license.php
+//=============================================================================
+/*:
+ * @plugindesc Create "motions" for map event characters
+ * @author SRPG Team
+ *
+ * @param Motions
+ * @type struct<MotionData>[]
+ * @desc List of standard motions available for events
+ *
+ * @param Compatability Mode
+ * @type boolean
+ * @desc Enable if another plugin changes how character animations loop
+ * @on YES
+ * @off NO
+ * @default false
+ *
+ * -------------------------------------------------------------------------------
+ * @param Default Motions
+ *
+ * @param Selected
+ * @parent Default Motions
+ * @type text
+ * @desc Motion played by the active unit
+ * Preferrably looping
+ *
+ * @param Attack
+ * @parent Default Motions
+ * @type text
+ * @desc Default motion when using Attack
+ * Preferrably non-looping
+ *
+ * @param Guard
+ * @parent Default Motions
+ * @type text
+ * @desc Default motion when using Guard
+ * Preferrably non-looping
+ *
+ * @param Physical Skill
+ * @parent Default Motions
+ * @type text
+ * @desc Default motion when using a physical skill
+ * Preferrably non-looping
+ *
+ * @param Magical Skill
+ * @parent Default Motions
+ * @parent Default Motions
+ * @type text
+ * @desc Default motion when using a magical skill
+ * Preferrably non-looping
+ *
+ * @param Certain Hit Skill
+ * @parent Default Motions
+ * @type text
+ * @desc Default motion when using a certain hit skill
+ * Preferrably non-looping
+ *
+ * @param Use Item
+ * @parent Default Motions
+ * @type text
+ * @desc Default motion when using an item
+ * Preferrably non-looping
+ *
+ * @param Damage
+ * @parent Default Motions
+ * @type text
+ * @desc Motion when taking damage
+ * Preferrably non-looping
+ *
+ * @param Evade
+ * @parent Default Motions
+ * @type text
+ * @desc Motion when evading
+ * Preferrably non-looping
+ *
+ *
+ * @param Screen Shake
+ * @desc Shake screen when dealing damage
+ * @type boolean
+ * @on ON
+ * @off OFF
+ * @default true
+ *
+ * @param Power
+ * @parent Screen Shake
+ * @type string
+ * @default 1+damage/50
+ *
+ * @param Speed
+ * @parent Screen Shake
+ * @type string
+ * @default critical ? 6 : 4
+ *
+ * @param Duration
+ * @parent Screen Shake
+ * @type string
+ * @default 10
+ * -------------------------------------------------------------------------------
+ *
+ * @help
+ * Based on DRQ_EventMotions.js, SRPG_MapBattle_Motions.js by Dr. Q
+ * and NRP_DynamicMotionMapEvent.js  by Takeshi Sunagawa
+ *
+ * Creates a system of "motions" for use with on-map events and players, similar
+ * to the one available in side-view battles. It can also be used to make
+ * reusable animations for cutscenes, map events, or other battle systems.
+ *
+ * By default, the index points to the event's current file, from 0 to 7. If you 
+ * need more than 8 motions, you can make use of the suffix- for example, if the
+ * event normally uses hero.png, a motion with the suffix _dead would use
+ * hero_dead.png. If you called the same animation on an event using villain.png,
+ * it would instead use villain_dead.png.
+ * 
+ *
+ * It also lets you configure a screen shake on dealing damage, for more impact.
+ * All three parameters are formulas, and you can use the following variables;
+ * "damage" is the raw damage dealt to the subject
+ * "critical" is true if the effect was a critical hit
+ * "damageRate" is damage / subject's max health, for scaling impact
+ *
+ * Actor notetags:
+ * <srpgBattleSuffix:X>  add a suffix to the actor's sprite name in battle
+ * <srpgBattleIndex:X>   change the actor's sprite index in battle
+ * 
+ * Actor, Class, Enemy, Weapon, Armor, and State notetag:
+ * <noMotions>  this character will not play new motions
+ * 
+ * State notetag:
+ * <idleMotion:X>  repeats motion X when no other motion is playing
+ * bypasses the noMotions tag
+ *
+ * Weapon notetag:
+ * <srpgAttackMotion:X>  use motion 'X' for the wielder's Attack
+ * 
+ * Skill / Item notetags:
+ * <srpgMotion:X>         use motion 'X' for the skill / item
+ * <useSrpgAttackMotion>  use the character's default attack motion for the skill
+ * <srpgCastMotion:X>     use motion 'X' before skill / item executes
+ * 
+ * New script call:
+ * event.playReactMotion('motion') plays the motion with the "reaction" flag, which
+ * stops map skills from waiting on its completion. Good for custom motions as part
+ * of skills or items, beyond the usual damage/evasion.
+ *
+ * Script calls:
+ *
+ * event.playMotion('motion') starts the event playing the specified motion
+ * event.clearMotion()        stops any motions in progress
+ * event.motion()             returns the current motion, or null if there isn't one
+ * event.hasLoopingMotion()   returns True if the event is playing a looping motion
+ * event.hasSingleMotion()    returns True if the event is playing a non-looping motion
+ * event.waitForMotion()      in move routes, waits for the current (non-looping) motion
+ * 
+ * You can also make a new motion on the fly with playCustomMotion:
+ * event.playCustomMotion({index: X, loop: true, wait: Y})
+ * If omitted, loop defaults to "false", and wait defaults to 0. Index is required.
+ */
+
+/*~struct~MotionData:
+ * @param Name
+ * @desc The name used to call this motion
+ * Capitalization doesn't matter
+ * @type text
+ *
+ * @param Index
+ * @desc The index on the character sheet for the motion
+ * -1 to use the default index
+ * @type number
+ * @min -1
+ * @default 0
+ *
+ * @param Suffix
+ * @desc Suffix to add to the character sheet filename
+ * @type text
+ *
+ * @param Wait
+ * @desc How long to wait between frames for this motion
+ * Set to 0 to keep the setting from the user's speed
+ * @type number
+ * @min 0
+ * @default 0
+ *
+ * @param Loop
+ * @desc What the motion does when it finishes playing
+ * Looping uses the same 0-1-2-1 pattern as normal walking
+ * @type select
+ * @option Play Once
+ * @value 0
+ * @option Hold Last Frame
+ * @value 1
+ * @option Loop
+ * @value 2
+ * @default 0
+ */
+
+(function(){
+
+function toBoolean(str) {
+    if (str == true) {
+        return true;
+    }
+    return (str == "true") ? true : false;
+}
+
+	var parameters = PluginManager.parameters('SRPG_MapviewBattler');
+	// the motion list is fairly complex, actually
+	Sprite_Character.MOTIONS = {};
+	if (parameters['Motions']) {
+		var _motionList = JSON.parse(parameters['Motions']);
+		for (var i = 0; i < _motionList.length; i++) {
+			if (_motionList[i]) {
+				var _motion = JSON.parse(_motionList[i]);
+				if (!_motion.Name || _motion.Name.length == 0) continue;
+				Sprite_Character.MOTIONS[_motion.Name.toUpperCase()] = {
+					index: Number(_motion.Index || 0),
+					wait: Number(_motion.Wait || 0),
+					loop: Number(_motion.Loop) == 2,
+					hold: Number(_motion.Loop) == 1,
+					suffix: _motion.Suffix || ''
+				};
+			}
+		}
+	}
+	var _compat = !!eval(parameters['Compatability Mode']) ? 0 : -1;
+
+// ------------------------------------------------------------------------------------------------
+	var _default = {};
+	_default.selected = parameters['Selected'];
+	_default.attack = parameters['Attack'];
+	_default.physical = parameters['Physical Skill'];
+	_default.magical = parameters['Magical Skill'];
+	_default.certain = parameters['Certain Hit Skill'];
+	_default.item = parameters['Use Item'];
+	_default.damage = parameters['Damage'];
+	_default.evade = parameters['Evade'];
+
+	var _shake = !!eval(parameters['Screen Shake']);
+	var _shakePower = parameters['Power'];
+	var _shakeSpeed = parameters['Speed'];
+	var _shakeFrames = parameters['Duration'];
+// ------------------------------------------------------------------------------------------------
+
+
+//====================================================================
+// Add motions to events
+//====================================================================
+
+	// initialize the motion property
+	_characterInitMembers = Game_CharacterBase.prototype.initMembers;
+	Game_CharacterBase.prototype.initMembers = function() {
+		_characterInitMembers.call(this);
+		this._motion = null;
+	};
+
+	// get the data object for the current motion
+	Game_CharacterBase.prototype.motion = function() {
+		return this._motion;
+	};
+
+	// check if there's a looping motion playing
+	Game_CharacterBase.prototype.hasLoopingMotion = function() {
+		var motion = this.motion();
+		return !!(motion && (motion.loop || motion.hold));
+	};
+
+	// check if there's a non-looping motion playing
+	Game_CharacterBase.prototype.hasSingleMotion = function() {
+		var motion = this.motion();
+		return !!(motion && !motion.loop && !motion.hold);
+	};
+
+	// remove any active motion
+	Game_CharacterBase.prototype.clearMotion = function() {
+		this._motion = null;
+		this._animationCount = 0;
+		this.resetPattern();
+	};
+
+	// run a preset motion
+	Game_CharacterBase.prototype.playMotion = function(motion, wait) {
+		if (!motion) return;
+		this.playCustomMotion(Sprite_Character.MOTIONS[motion.toUpperCase()], wait);
+	};
+
+	// run a motion created on the fly
+	Game_CharacterBase.prototype.playCustomMotion = function(motionData, wait) {
+		this._motion = motionData;
+		if (this._motion) {
+			motionData.loop ? this.resetPattern() : this._pattern = 0;
+			this._animationCount = 0;
+
+			if (wait && !motionData.loop) {
+				this._waitCount = this.animationWait() * (this.maxPattern() + _compat);
+			}
+		}
+	};
+
+	// wait for the current motion to finish (non-looping only)
+	Game_CharacterBase.prototype.waitForMotion = function() {
+		var motion = this.motion();
+		if (!motion || motion.loop) return;
+		var frameWait = this.animationWait();
+		var frameCount = this.maxPattern() - this._pattern + _compat;
+		var partialFrame = this._animationCount;
+		// technically, it just computes the remaining motion duration
+		this._waitCount = frameWait * frameCount - partialFrame;
+	};
+
+//====================================================================
+// Use the active motion instead of normal properties
+//====================================================================
+
+	// when a motion is active, you always animate
+	var _hasStepAnime = Game_CharacterBase.prototype.hasStepAnime;
+	Game_CharacterBase.prototype.hasStepAnime = function() {
+		if (this.motion()) {
+			return true;
+		} else {
+			return _hasStepAnime.call(this);
+		}
+	};
+
+	// override the character index for motions
+	var _characterIndex = Game_CharacterBase.prototype.characterIndex;
+	Game_CharacterBase.prototype.characterIndex = function() {
+		if (this.motion() && this.motion().index >= 0) {
+			return this.motion().index;
+		} else {
+			return _characterIndex.call(this);
+		}
+	};
+
+	// override the character file for motions (rarely used)
+	var _characterName = Game_CharacterBase.prototype.characterName;
+	Game_CharacterBase.prototype.characterName = function() {
+		var baseName = _characterName.call(this);
+		if (baseName !== '' && this.motion() && this.motion().suffix) {
+			return baseName + this.motion().suffix;
+		} else {
+			return baseName;
+		}
+	};
+
+	// override normal animation wait for motions
+	var _animationWait = Game_CharacterBase.prototype.animationWait;
+	Game_CharacterBase.prototype.animationWait = function() {
+		if (this.motion() && this.motion().wait > 0) {
+			return this.motion().wait;
+		} else {
+			return _animationWait.call(this);
+		}
+	};
+
+	// update the motion, and reset at the end of a non-looping, non-held motion
+	var _updatePattern = Game_CharacterBase.prototype.updatePattern;
+	Game_CharacterBase.prototype.updatePattern = function() {
+		var motion = this.motion();
+		if (motion) {
+			if (motion.loop) {
+				this._pattern = (this._pattern + 1) % this.maxPattern();
+			} else if (this._pattern < this.maxPattern() + _compat - 1) {
+				this._pattern++;
+			} else if (motion.hold) {
+				motion._done = true;
+			} else {
+				this.clearMotion();
+			}
+		} else {
+			_updatePattern.call(this);
+		}
+	};
+// -----------------------------------------------------------------------------------------
+
+//====================================================================
+// Custom in-battle sprites for actors
+//====================================================================
+
+	// actors can have different sprites for in-combat
+	var _refreshImage = Game_Event.prototype.refreshImage;
+	Game_Event.prototype.refreshImage = function() {
+		if ($gameSystem.isSRPGMode() && !this.isErased()) {
+			var battlerArray = $gameSystem.EventToUnit(this.eventId());
+			if (battlerArray && battlerArray[0] == 'actor') {
+				var actor = battlerArray[1];
+				var suffix = actor.actor().meta.srpgBattleSuffix || '';
+				var index = actor.actor().meta.srpgBattleIndex || actor.characterIndex();
+				this.setImage(actor.characterName()+suffix, index);
+				return;
+			}
+		}
+		_refreshImage.call(this);
+	};
+
+//====================================================================
+// Handle motions on the whole party at once
+//====================================================================
+
+	// check if anyone in the party is playing a motion
+	Game_Party.prototype.hasMotion = function() {
+		return this.members().some(function(actor) {
+			var event = actor.event();
+			return event ? event.hasMotion() : false;
+		});
+	};
+
+	// check if anyone in the party is playing a looping motion
+	Game_Party.prototype.hasLoopingMotion = function() {
+		return this.members().some(function(actor) {
+			var event = actor.event();
+			return event ? event.hasLoopingMotion() : false;
+		});
+	};
+
+	// check if anyone in the party is playing a non-looping motion
+	Game_Party.prototype.hasSingleMotion = function() {
+		return this.members().some(function(actor) {
+			var event = actor.event();
+			return event ? event.hasSingleMotion() : false;
+		});
+	};
+
+	// run a preset motion on the entire party
+	Game_Party.prototype.playMotion = function(motion, wait) {
+		if (!motion) return;
+		this.playCustomMotion(Sprite_Character.MOTIONS[motion.toUpperCase()], wait);
+	};
+
+	// run a motion defined on the fly on the entire party
+	Game_Party.prototype.playCustomMotion = function(motionData, wait) {
+		if (!$gameSystem.isSRPGMode()) return;
+		this.members().forEach(function (actor) {
+			var event = actor.event();
+			if (!event || actor.noMotions()) return;
+			event.playCustomMotion(motionData, wait);
+		});
+	};
+
+	// clear the motions for the whole party
+	Game_Party.prototype.clearMotion = function() {
+		this.members().forEach(function (actor) {
+			var event = actor.event();
+			if (event) event.clearMotion();
+		});
+	};
+
+//====================================================================
+// Integrate motions with combat
+//====================================================================
+
+	// adjusted motion for reactions (evade / damaged)
+	Game_CharacterBase.prototype.playReactMotion = function(motion, wait) {
+		var baseMotion = Sprite_Character.MOTIONS[motion.toUpperCase()];
+		if (!baseMotion) return;
+		var reactMotion = {
+			index: baseMotion.index,
+			wait: baseMotion.wait,
+			loop: baseMotion.loop,
+			hold: baseMotion.hold,
+			suffix: baseMotion.suffix,
+			reaction: true
+		};
+		this.playCustomMotion(reactMotion, wait);
+	}
+
+	// get the motion for a basic attack
+	Game_BattlerBase.prototype.mapAttackMotion = function() {
+		return _default.attack;
+	};
+	Game_Actor.prototype.mapAttackMotion = function() {
+		var motion = _default.attack
+		this.weapons().forEach(function(weapon) {
+			if (weapon && weapon.meta.srpgAttackMotion) motion = weapon.meta.srpgAttackMotion;
+		});
+		return motion;
+	};
+	Game_Enemy.prototype.mapAttackMotion = function() {
+		if (!this.hasNoWeapons()) {
+			var weapon = $dataWeapons[this.enemy().meta.srpgWeapon];
+			if (weapon && weapon.meta.srpgAttackMotion) return weapon.meta.srpgAttackMotion;
+		}
+		return _default.attack;
+	};
+
+	// play the motions for an action
+	var _srpgInvokeMapSkill = Scene_Map.prototype.srpgInvokeMapSkill;
+	Scene_Map.prototype.srpgInvokeMapSkill = function(data) {
+		var action = data.action;
+		var user = data.user;
+		var event = user.event();
+		if (event && !user.noMotions()) {
+			if (data.phase === 'start') {
+				var motion = action.item().meta.srpgCastMotion;
+				if (motion) event.playMotion(motion);
+			} else if (data.phase === 'animation') {
+				var motion = action.item().meta.srpgMotion;
+				if (motion) event.playMotion(motion);
+				else if (action.isAttack() || action.item().meta.useSrpgAttackMotion) event.playMotion(user.mapAttackMotion());
+				else if (action.isItem()) event.playMotion(_default.item);
+				else if (action.isPhysical()) event.playMotion(_default.physical);
+				else if (action.isMagical()) event.playMotion(_default.magical);
+				else if (action.isCertainHit()) event.playMotion(_default.certain);
+			} else if (data.phase === 'end') {
+				event.clearMotion();
+			}
+		}
+		_srpgInvokeMapSkill.call(this, data);
+	};
+
+	// special damage effects
+	var _srpgShowResults = Game_BattlerBase.prototype.srpgShowResults;
+	Game_BattlerBase.prototype.srpgShowResults = function() {
+		_srpgShowResults.call(this);
+		var result = this.result();
+
+		if (!$gameSystem.useMapBattle()) return;
+
+		var event = this.event();
+		if (event && !this.noMotions()) {
+			if (result.isHit() && result.hpDamage > 0) event.playReactMotion(_default.damage);
+			else if (result.missed || result.evaded) event.playReactMotion(_default.evade);
+		}
+
+		if (_shake && result.hpDamage > 0) {
+			var damage = result.hpDamage;
+			var damageRate = (damage / this.mhp);
+			var critical = result.isCritical;
+
+			var power = Math.floor(Number(eval(_shakePower)));
+			var speed = Math.floor(Number(eval(_shakeSpeed)));
+			var frames = Math.floor(Number(eval(_shakeFrames)));
+
+			$gameScreen.startShake(power, speed, frames);
+		}
+	};
+
+	// active event shows a running animation
+	var _setActiveEvent = Game_Temp.prototype.setActiveEvent;
+	Game_Temp.prototype.setActiveEvent = function(event) {
+		var oldEvent = $gameTemp.activeEvent();
+		_setActiveEvent.call(this, event);
+		if (oldEvent) oldEvent.clearMotion();
+		if ($gameSystem.EventToUnit(event.eventId())[1].noMotions()) return;
+		event.playMotion(_default.selected);
+	};
+	var _clearActiveEvent = Game_Temp.prototype.clearActiveEvent;
+	Game_Temp.prototype.clearActiveEvent = function() {
+		var oldEvent = $gameTemp.activeEvent();
+		_clearActiveEvent.call(this);
+		if (oldEvent) oldEvent.clearMotion();
+	};
+
+	// wait for motions to finish before advancing a skill
+	var _waitingForSkill = Scene_Map.prototype.waitingForSkill;
+	Scene_Map.prototype.waitingForSkill = function() {
+		if (this.skillAnimWait()) {
+			var active = $gameTemp.activeEvent();
+			if (active.hasSingleMotion() && !active.motion().idle && !active.motion().reaction) {
+				return true;
+			}
+
+			var target = $gameTemp.targetEvent();
+			if (target && target.hasSingleMotion() && !target.motion().idle && !target.motion().reaction){
+				return true;
+			}
+		}
+
+		return _waitingForSkill.call(this);
+	};
+
+//====================================================================
+// State-based Idle Motions (not affected by noMotions)
+//====================================================================
+
+	// get idle motions from states
+	Game_BattlerBase.prototype.mapIdleMotion = function() {
+		for (var i = 0; i < this.states().length; i++) {
+			var state = this.states()[i];
+			if (state && state.meta.idleMotion) {
+				var motion = Sprite_Character.MOTIONS[state.meta.idleMotion.toUpperCase()];
+				if (motion != null) {
+					return {
+						index: motion.index,
+						wait: motion.wait,
+						loop: motion.loop,
+						hold: motion.hold,
+						suffix: motion.suffix,
+						idle: true
+					};
+				}
+			}
+		}
+		return null;
+	};
+
+	// if the battler has an idle motion, switch back to it any time it clears
+	var _clearMotion = Game_CharacterBase.prototype.clearMotion;
+	Game_CharacterBase.prototype.clearMotion = function() {
+		_clearMotion.call(this);
+		if ($gameSystem.isSRPGMode()) {
+			var battlerArray = $gameSystem.EventToUnit(this.eventId());
+			if (battlerArray) {
+				var idleMotion = battlerArray[1].mapIdleMotion();
+				if (idleMotion) {
+					this.playCustomMotion(idleMotion, false);
+				}
+			}
+		}
+	};
+
+	// update the idle motion when a state is added
+	var _addState = Game_Battler.prototype.addState;
+	Game_Battler.prototype.addState = function(stateId) {
+		_addState.call(this, stateId);
+		if ($gameSystem.isSRPGMode() && this.event()) {
+			if (!this.event().motion() || this.event().motion().idle) {
+				var idleMotion = this.mapIdleMotion();
+				if (idleMotion) {
+					this.event().playCustomMotion(idleMotion, false);
+				}
+			}
+		}
+	};
+
+	// Update idle motion as soon as a state is removed
+	var _removeState = Game_Battler.prototype.removeState;
+	Game_Battler.prototype.removeState = function(stateId) {
+		_removeState.call(this, stateId);
+		if ($gameSystem.isSRPGMode() && this.event() &&
+		this.event().motion() && this.event().motion().idle) {
+			this.event().clearMotion();
+		}
+	};
+
+//====================================================================
+// Ignore Motions
+//====================================================================
+
+	// check if a battler won't play motions due to a state
+	Game_BattlerBase.prototype.noMotions = function() {
+		var noMotion = false;
+		this.states().forEach(function(state) {
+			if (state.meta.noMotions) {
+				noMotion = true;
+			}
+		});
+		return noMotion;
+	};
+
+	// check if an actor won't play motions due to class or equipment
+	Game_Actor.prototype.noMotions = function() {
+		if (this.actor().meta.noMotions) return true;
+		if (this.currentClass().meta.noMotions) return true;
+
+		var noMotion = false;
+		this.equips().forEach(function(item) {
+			if (item && item.meta.noMotions) {
+				noMotion = true;
+			}
+		});
+
+		return noMotion || Game_BattlerBase.prototype.noMotions.call(this);
+	};
+
+	// check if an enemy won't play motions innately or due to their weapon
+	Game_Enemy.prototype.noMotions = function() {
+		if (this.enemy().meta.noMotions) return true;
+
+		if (!this.hasNoWeapons()) {
+			var weapon = $dataWeapons[this.enemy().meta.srpgWeapon];
+			if (weapon && weapon.meta.noMotions) return true;
+		}
+
+		return Game_BattlerBase.prototype.noMotions.call(this);
+	};
+// -------------------------------------------------------------------------------
+/**
+ * ●SVキャラクターモーションの実行
+ * ※NRP_DynamicMotionの関数
+ */
+	const _Sprite_Character_startDynamicSvMotion = Sprite_Character.prototype.startDynamicSvMotion;
+	Sprite_Character.prototype.startDynamicSvMotion = function(dynamicMotion) {
+ 	   // Game_CharacterBase側で処理する。
+   	 this._character.startDynamicSvMotion(dynamicMotion);
+	};
+
+/**
+ * ●SVキャラクターモーションの実行
+ */
+	Game_CharacterBase.prototype.startDynamicSvMotion = function(dynamicMotion) {
+    	const bm = dynamicMotion.baseMotion;
+    	const dm = dynamicMotion;
+
+    	// モーションが取得できなければ終了
+    	if (!dm.motion) {
+    	    return;
+   	}
+
+   	 // eval参照用
+   	const a = dm.referenceSubject;
+    	const subject = bm.getReferenceSubject();
+   	const b = dm.referenceTarget;
+    	const repeat = dm.repeat;
+    	const r = dm.r;
+
+    	// モーションリセット
+    	this._pattern = 0;
+
+    	// モーションパターン
+    	this._motionPattern = dm.motionPattern;
+    	// モーション開始パターン
+    	if (dm.motionStartPattern != undefined) {
+        	this._motionStartPattern = eval(dm.motionStartPattern);
+    	}
+
+    	// DRQ_EventMotionを呼び出し
+    	this.playMotion(dm.motion, dm.motionDuration);
+	};
+
+	/**
+ 	* ●モーション実行
+ 	* ※DRQ_EventMotionsの関数
+ 	*/
+	const _Game_CharacterBase_playCustomMotion = Game_CharacterBase.prototype.playCustomMotion;
+	Game_CharacterBase.prototype.playCustomMotion = function(motionData, wait) {
+    	_Game_CharacterBase_playCustomMotion.apply(this, arguments);
+
+    		if (this._motion) {
+        		// モーション開始パターンの変更
+        		if (this._motionStartPattern) {
+            		this._pattern = this._motionStartPattern;
+            		this._motionStartPattern = undefined;
+        		}
+    		}
+	};
+
+	/**
+ 	* ●モーションパターンの更新
+ 	*/
+	const _Game_CharacterBase_updatePattern = Game_CharacterBase.prototype.updatePattern;
+	Game_CharacterBase.prototype.updatePattern = function() {
+    	const motion = this.motion();
+    	if (motion) {
+        	// モーションパターンの指定がある場合
+        	if (this._motionPattern != undefined) {
+            	// 指定式でパターン制御
+            	this._pattern = eval(this._motionPattern);
+            	// 値がマイナスになった場合はクリア
+            	if (this._pattern < 0) {
+                	this.clearMotion();
+                	this._motionPattern = undefined;
+            	}
+            	return;
+        	}
+    	}
+
+    	_Game_CharacterBase_updatePattern.apply(this, arguments);
+	};
+})();

--- a/SRPG_MouseOperation.js
+++ b/SRPG_MouseOperation.js
@@ -313,6 +313,45 @@ Game_Map.prototype.scrollDownRight = function(distance) {
     this.scrollRight(distance);
 };
 
+
+//=============================================================================
+// Update setHiddenPointer for some battlePhase & subBattlePhase
+//=============================================================================
+
+// setHiddenPointer in the beginning of actor turn
+$.srpgStartActorTurn = Game_System.prototype.srpgStartActorTurn;
+Game_System.prototype.srpgStartActorTurn = function() {
+    $.srpgStartActorTurn.call(this);
+    Graphics.setHiddenPointer(true);
+};
+
+// setHiddenPointer after selecting any command
+// I don't know how to prevent Graphics.setHiddenPointer(false); in $.TouchInput_onMouseMove to be executed until the cursor really arrived to target
+$.startActorTargetting = Scene_Map.prototype.startActorTargetting;
+Scene_Map.prototype.startActorTargetting = function() {
+    $.startActorTargetting.call(this);
+    Graphics.setHiddenPointer(true);
+};
+
+// setHiddenPointer after any action
+// I don't know how to prevent Graphics.setHiddenPointer(false); in $.TouchInput_onMouseMove to be executed until the cursor really arrived to target
+$.srpgAfterAction = Scene_Map.prototype.srpgAfterAction;
+Scene_Map.prototype.srpgAfterAction = function() {
+    $.srpgAfterAction.call(this);
+    if ($gameSystem.isBattlePhase() === 'actor_phase') {
+        Graphics.setHiddenPointer(true);
+    }
+};
+
+
+/* It seems this block of code can be used for Graphics.setHiddenPointer(true); in some subBattlePhase
+$.srpgControlPhase = Scene_Map.prototype.srpgControlPhase;
+Scene_Map.prototype.srpgControlPhase = function() {
+    $.srpgControlPhase.call(this);
+    // additional function here    
+};
+*/
+
 //=============================================================================
 // Input
 //=============================================================================
@@ -324,7 +363,7 @@ Input.update = function() {
 };
 
 //=============================================================================
-// TouchInput
+// MouseInput
 //=============================================================================
 $.TouchInput_onMouseMove = TouchInput._onMouseMove;
 TouchInput._onMouseMove = function(event) {
@@ -334,13 +373,47 @@ TouchInput._onMouseMove = function(event) {
   Graphics.setHiddenPointer(false);
 };
 
+$.TouchInput_onWheel = TouchInput._onWheel;
+TouchInput._onWheel = function(event) {
+    $.TouchInput_onWheel.call(this, event);
+    if ($gameSystem.isSRPGMode()) {
+        Graphics.setHiddenPointer(true);
+    }
+};
+
+
+// Note for Mr Takumi Ariake
+// I created the initial function for $.TouchInput_onLeftButtonDown, where a left mouse click will make the mouse pointer to reappear.
+// But I haven't found a way to make the mouse pointer reappear right above the event where the current cursor(player) position is
+//  and directly select that event to enter the next subbattlephase.
+// This is the function used by SRPG Studio software.
+
+/* The function
+$.TouchInput_onLeftButtonDown = TouchInput._onLeftButtonDown;
+TouchInput._onLeftButtonDown = function(event) {
+    $.TouchInput_onLeftButtonDown.call(this, event);
+    if ($gameSystem.isSRPGMode()) {
+        Graphics.setHiddenPointer(false);
+    }
+};
+*/
+
+//=============================================================================
+// TouchInput
+//=============================================================================
+$.TouchInput_onTouchStart = TouchInput._onTouchStart;
+TouchInput._onTouchStart = function(event) {
+    $.TouchInput_onTouchStart.call(this, event);
+    Graphics.setHiddenPointer(true);
+};
+
 TouchInput.atLeftBorder = function(){
   if(this._mouseX < $.Parameters.borderDistance1) return true;
   return false;
 };
 
 TouchInput.atRightBorder = function(){
-  if(this._mouseX > Graphics.boxWidth - $.Parameters.borderDistance1) return true;
+  if(this._mouseX > Graphics.width - $.Parameters.borderDistance1) return true;
   return false;
 };
 
@@ -350,7 +423,7 @@ TouchInput.atTopBorder = function(){
 };
 
 TouchInput.atBottomBorder = function(){
-  if(this._mouseY > Graphics.boxHeight - $.Parameters.borderDistance1) return true;
+  if(this._mouseY > Graphics.height - $.Parameters.borderDistance1) return true;
   return false;
 };
 
@@ -360,7 +433,7 @@ TouchInput.atDeepLeftBorder = function(){
 };
 
 TouchInput.atDeepRightBorder = function(){
-  if(this._mouseX > Graphics.boxWidth - $.Parameters.borderDistance2) return true;
+  if(this._mouseX > Graphics.width - $.Parameters.borderDistance2) return true;
   return false;
 };
 
@@ -370,7 +443,7 @@ TouchInput.atDeepTopBorder = function(){
 };
 
 TouchInput.atDeepBottomBorder = function(){
-  if(this._mouseY > Graphics.boxHeight - $.Parameters.borderDistance2) return true;
+  if(this._mouseY > Graphics.height - $.Parameters.borderDistance2) return true;
   return false;
 };
 

--- a/SRPG_core.js
+++ b/SRPG_core.js
@@ -6121,6 +6121,24 @@
         }
     };
 
+    // Overriding the startEntryMotion method of Sprite_Actor
+    Sprite_Actor.prototype.startEntryMotion = function() {
+        if ($gameSystem.isSRPGMode()) {
+            // Code to execute during SRPG mode
+            // Directly set the actor's position to their battle position
+            this.setHome(this._homeX, this._homeY);
+            this.moveToStartPosition();
+        }
+    };
+
+    // Override moveToStartPosition to prevent movement
+    Sprite_Actor.prototype.moveToStartPosition = function() {
+        if ($gameSystem.isSRPGMode()) {
+            // Code to execute during SRPG mode
+            // Overriding this method to prevent the actor from moving to start position
+        }
+    };
+
 //====================================================================
 // ●Sprite_Character
 //====================================================================


### PR DESCRIPTION
Dear Mr. Ariake Takumi,

SRPG Gear MV serves as the successor to SRPG Converter MV, bringing additional features and crucial bug fixes that greatly benefit SRPG development. Breaking compatibility was unavoidable, so efforts have been made to ensure that previous features remain accessible and can eventually be transitioned to SRPG Gear MZ.

I have endeavored to thoroughly understand the differences between SRPG Gear MV and SRPG Converter MV, attempting to restore features that are no longer compatible.

Some of the features I've worked to reinstate include:
- SRPG_AoEAnimation: an extension to enable sideview battles to display all enemies targeted by an AoE attack, similar to on-map battles.
- SRPG_DynamicAction: an extension to add animated battlers for both sideview and mapview battlers, significantly enhancing the visual appeal of battles.
- Various additional features from the English-speaking community.

The primary issue with the patches I've provided stems from my limited understanding of the new features in SRPG_AoE, which means I can't patch it perfectly without reverting to old functions, a method that might not be the best approach in programming.

I would greatly appreciate your review and feedback on the changes I've made.

Thank you very much.